### PR TITLE
Add EC multiplication dispatcher module for production

### DIFF
--- a/src/EC_Multiplication_Dispatch.bas
+++ b/src/EC_Multiplication_Dispatch.bas
@@ -1,0 +1,147 @@
+Attribute VB_Name = "EC_Multiplication_Dispatch"
+Option Explicit
+
+' =============================================================================
+' EC MULTIPLICATION DISPATCH - ESCOLHA AUTOMÁTICA DE ALGORITMOS
+' =============================================================================
+' Responsável por selecionar a melhor estratégia de multiplicação escalar
+' considerando tamanho do escalar, segurança (constant-time) e heurísticas
+' de uso de pontos. Implementação derivada dos testes de performance, com
+' dependências ajustadas para o ambiente de produção.
+' =============================================================================
+
+Private Const CACHE_USAGE_THRESHOLD As Long = 3
+
+Private Type POINT_USAGE_ENTRY
+    signature As String
+    hits As Long
+End Type
+
+Private point_usage_initialized As Boolean
+Private point_usage() As POINT_USAGE_ENTRY
+Private next_usage_slot As Long
+
+' =============================================================================
+' MULTIPLICAÇÃO ESCALAR "ULTIMATE"
+' =============================================================================
+
+Public Function ec_point_mul_ultimate(ByRef result As EC_POINT, ByRef scalar As BIGNUM_TYPE, ByRef point As EC_POINT, ByRef ctx As SECP256K1_CTX) As Boolean
+    Dim scalar_bits As Long
+    scalar_bits = BN_num_bits(scalar)
+
+    If is_generator_point(point, ctx) Then
+        If EC_Precomputed_Manager.use_precomputed_gen_tables() Then
+            ec_point_mul_ultimate = ec_generator_mul_precomputed_naf(result, scalar, ctx)
+        Else
+            ec_point_mul_ultimate = EC_Precomputed_Manager.ec_generator_mul_fast(result, scalar, ctx)
+        End If
+    ElseIf scalar_bits > 200 Then
+        ec_point_mul_ultimate = ec_point_mul_glv(result, scalar, point, ctx)
+    ElseIf scalar_bits > 128 Then
+        If require_constant_time() Then
+            ec_point_mul_ultimate = ec_point_mul_ladder(result, scalar, point, ctx)
+        ElseIf should_use_cached_point(point) Then
+            ec_point_mul_ultimate = ec_point_mul_cached(result, scalar, point, ctx)
+        Else
+            ec_point_mul_ultimate = ec_point_mul_sliding_naf(result, scalar, point, ctx)
+        End If
+    Else
+        ec_point_mul_ultimate = ec_point_mul(result, scalar, point, ctx)
+    End If
+End Function
+
+' =============================================================================
+' EXPONENCIAÇÃO MODULAR AUTOMÁTICA
+' =============================================================================
+
+Public Function BN_mod_exp_ultimate(ByRef r As BIGNUM_TYPE, ByRef a As BIGNUM_TYPE, ByRef e As BIGNUM_TYPE, ByRef m As BIGNUM_TYPE) As Boolean
+    Dim exp_bits As Long
+    exp_bits = BN_num_bits(e)
+
+    If is_secp256k1_prime(m) And exp_bits > 64 Then
+        Dim mont_ctx As MONT_CTX
+        mont_ctx = BN_MONT_CTX_new()
+        If Not BN_MONT_CTX_set(mont_ctx, m) Then
+            BN_mod_exp_ultimate = False
+            Exit Function
+        End If
+        BN_mod_exp_ultimate = BN_mod_exp_mont(r, a, e, m, mont_ctx)
+    ElseIf exp_bits > 128 Then
+        BN_mod_exp_ultimate = BN_mod_exp_win4(r, a, e, m)
+    Else
+        BN_mod_exp_ultimate = BN_mod_exp(r, a, e, m)
+    End If
+End Function
+
+' =============================================================================
+' HELPER FUNCTIONS
+' =============================================================================
+
+Private Function is_generator_point(ByRef point As EC_POINT, ByRef ctx As SECP256K1_CTX) As Boolean
+    If point.infinity Then
+        is_generator_point = False
+    Else
+        is_generator_point = (ec_point_cmp(point, ctx.g, ctx) = 0)
+    End If
+End Function
+
+Private Function should_use_cached_point(ByRef point As EC_POINT) As Boolean
+    If point.infinity Then
+        should_use_cached_point = False
+        Exit Function
+    End If
+
+    If Not point_usage_initialized Then
+        ReDim point_usage(0 To 7)
+        point_usage_initialized = True
+        next_usage_slot = 0
+    End If
+
+    Dim signature As String
+    signature = point_signature(point)
+
+    Dim i As Long
+    For i = LBound(point_usage) To UBound(point_usage)
+        If point_usage(i).signature = signature Then
+            point_usage(i).hits = point_usage(i).hits + 1
+            should_use_cached_point = (point_usage(i).hits >= CACHE_USAGE_THRESHOLD)
+            Exit Function
+        End If
+    Next i
+
+    For i = LBound(point_usage) To UBound(point_usage)
+        If point_usage(i).signature = "" Then
+            point_usage(i).signature = signature
+            point_usage(i).hits = 1
+            should_use_cached_point = False
+            Exit Function
+        End If
+    Next i
+
+    point_usage(next_usage_slot).signature = signature
+    point_usage(next_usage_slot).hits = 1
+    next_usage_slot = (next_usage_slot + 1) Mod (UBound(point_usage) + 1)
+
+    should_use_cached_point = False
+End Function
+
+Private Function point_signature(ByRef point As EC_POINT) As String
+    If point.infinity Then
+        point_signature = "INF"
+    Else
+        point_signature = Left$(BN_bn2hex(point.x), 32) & ":" & Left$(BN_bn2hex(point.y), 32)
+    End If
+End Function
+
+Private Function is_secp256k1_prime(ByRef m As BIGNUM_TYPE) As Boolean
+    Static secp_p As BIGNUM_TYPE
+    Static initialized As Boolean
+
+    If Not initialized Then
+        secp_p = BN_hex2bn("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F")
+        initialized = True
+    End If
+
+    is_secp256k1_prime = (BN_cmp(m, secp_p) = 0)
+End Function
+

--- a/tests/Performance_Integration.bas
+++ b/tests/Performance_Integration.bas
@@ -5,69 +5,6 @@ Option Explicit
 ' PERFORMANCE INTEGRATION - INTEGRAÇÃO COMPLETA DAS OTIMIZAÇÕES
 ' =============================================================================
 
-Public Function ec_point_mul_ultimate(ByRef result As EC_POINT, ByRef scalar As BIGNUM_TYPE, ByRef point As EC_POINT, ByRef ctx As SECP256K1_CTX) As Boolean
-    ' Seleção automática da melhor técnica de multiplicação escalar
-    Dim scalar_bits As Long
-    scalar_bits = BN_num_bits(scalar)
-    
-    ' Seleção baseada em benchmarks empíricos + segurança
-    If is_generator_point(point, ctx) Then
-        ' Ponto gerador: PRIORIDADE 1 - Tabelas pré-computadas (1760 pontos) + NAF
-        If use_precomputed_gen_tables() Then
-            ec_point_mul_ultimate = ec_generator_mul_precomputed_naf(result, scalar, ctx)
-        Else
-            ec_point_mul_ultimate = EC_Precomputed_Manager.ec_generator_mul_fast(result, scalar, ctx)
-        End If
-    ElseIf scalar_bits > 200 Then
-        ' Escalares grandes: GLV endomorphism (40-50% melhoria)
-        ec_point_mul_ultimate = ec_point_mul_glv(result, scalar, point, ctx)
-    ElseIf scalar_bits > 128 Then
-        ' Escalares médios: Seleção avançada baseada em contexto
-        If require_constant_time() Then
-            ec_point_mul_ultimate = ec_point_mul_ladder(result, scalar, point, ctx)
-        ElseIf Final_Optimizations_Test.is_frequent_point(point) Then
-            ec_point_mul_ultimate = ec_point_mul_cached(result, scalar, point, ctx)
-        Else
-            ec_point_mul_ultimate = ec_point_mul_sliding_naf(result, scalar, point, ctx)
-        End If
-    Else
-        ' Escalares pequenos: Multiplicação regular
-        ec_point_mul_ultimate = ec_point_mul(result, scalar, point, ctx)
-    End If
-End Function
-
-Public Function BN_mod_exp_ultimate(ByRef r As BIGNUM_TYPE, ByRef a As BIGNUM_TYPE, ByRef e As BIGNUM_TYPE, ByRef m As BIGNUM_TYPE) As Boolean
-    ' Exponenciação modular com seleção automática
-    Dim exp_bits As Long
-    exp_bits = BN_num_bits(e)
-    
-    If is_secp256k1_prime(m) And exp_bits > 64 Then
-        ' Usar Montgomery para módulos secp256k1 e expoentes grandes
-        Dim mont_ctx As MONT_CTX
-        mont_ctx = BN_MONT_CTX_new()
-        Call BN_MONT_CTX_set(mont_ctx, m)
-        BN_mod_exp_ultimate = BN_mod_exp_mont(r, a, e, m, mont_ctx)
-    ElseIf exp_bits > 128 Then
-        ' Usar janelas para expoentes grandes
-        BN_mod_exp_ultimate = BN_mod_exp_win4(r, a, e, m)
-    Else
-        ' Usar algoritmo padrão para expoentes pequenos
-        BN_mod_exp_ultimate = BN_mod_exp(r, a, e, m)
-    End If
-End Function
-
-Private Function is_generator_point(ByRef point As EC_POINT, ByRef ctx As SECP256K1_CTX) As Boolean
-    ' Verifica se é o ponto gerador
-    is_generator_point = (ec_point_cmp(point, ctx.g, ctx) = 0)
-End Function
-
-Private Function is_secp256k1_prime(ByRef m As BIGNUM_TYPE) As Boolean
-    ' Verifica se é o primo secp256k1
-    Dim secp_p As BIGNUM_TYPE
-    secp_p = BN_hex2bn("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F")
-    is_secp256k1_prime = (BN_cmp(m, secp_p) = 0)
-End Function
-
 Public Sub integrate_all_optimizations()
     ' Integra todas as otimizações no sistema principal
     Debug.Print "=== INTEGRAÇÃO COMPLETA DE OTIMIZAÇÕES ==="


### PR DESCRIPTION
## Summary
- add a production EC_Multiplication_Dispatch module that selects optimized scalar multiplication and modular exponentiation strategies without QA dependencies
- replace the Final_Optimizations_Test frequency heuristic with an internal point usage tracker suitable for runtime use
- remove the duplicate test-only implementations now that production code exposes the dispatcher

## Testing
- not run (VBA environment not available)


------
https://chatgpt.com/codex/tasks/task_e_68e067ec20f08333af72f9a0b0c8ded5