### PR TITLE
Validate imported private keys and extend tests

### DIFF
--- a/src/EC_secp256k1_ECDSA.bas
+++ b/src/EC_secp256k1_ECDSA.bas
@@ -398,6 +398,26 @@ Public Function ecdsa_set_private_key(ByRef private_key_hex As String, ByRef ctx
     ' Retorna: Par de chaves com chave pública derivada
     Dim keypair As ECDSA_KEYPAIR
     keypair.private_key = BN_hex2bn(private_key_hex)
+
+    Dim zero As BIGNUM_TYPE, curve_order As BIGNUM_TYPE
+    zero = BN_new()
+
+    If ctx.n.top = 0 Then
+        curve_order = BN_hex2bn("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141")
+    Else
+        curve_order = ctx.n
+    End If
+
+    If BN_ucmp(keypair.private_key, zero) <= 0 Then
+        Err.Raise vbObjectError + &H1002&, "ecdsa_set_private_key", _
+                  "Chave privada inválida: deve ser maior que zero."
+    End If
+
+    If BN_ucmp(keypair.private_key, curve_order) >= 0 Then
+        Err.Raise vbObjectError + &H1002&, "ecdsa_set_private_key", _
+                  "Chave privada inválida: deve ser menor que a ordem da curva."
+    End If
+
     keypair.public_key = ec_point_new()
     Call ec_point_mul_ultimate(keypair.public_key, keypair.private_key, ctx.g, ctx)
     ecdsa_set_private_key = keypair

--- a/src/secp256k1_API.bas
+++ b/src/secp256k1_API.bas
@@ -85,7 +85,16 @@ End Function
 
 Public Function secp256k1_private_key_from_hex(ByVal private_key_hex As String) As ECDSA_KEYPAIR
     ' Cria par de chaves a partir de uma chave privada em formato hexadecimal
+    last_error = SECP256K1_OK
+
+    On Error GoTo InvalidPrivateKey
     secp256k1_private_key_from_hex = ecdsa_set_private_key(private_key_hex, ctx)
+    Exit Function
+
+InvalidPrivateKey:
+    last_error = SECP256K1_ERROR_INVALID_PRIVATE_KEY
+    Dim empty_keypair As ECDSA_KEYPAIR
+    secp256k1_private_key_from_hex = empty_keypair
 End Function
 
 Public Function secp256k1_public_key_from_private(ByVal private_key_hex As String, Optional ByVal compressed As Boolean = True) As String

--- a/tests/Test_API_Complete.bas
+++ b/tests/Test_API_Complete.bas
@@ -214,6 +214,73 @@ Private Sub Test_API_Key_Validation(ByRef passed As Long, ByRef total As Long)
         Debug.Print "FALHOU: Aceitou chave pública inválida"
     End If
     total = total + 1
+
+    ' Testes de importação de chaves privadas nos limites
+    Dim imported As ECDSA_KEYPAIR
+    Dim err_code As SECP256K1_ERROR
+    Dim expected As BIGNUM_TYPE
+
+    Dim min_valid As String
+    min_valid = String(63, "0") & "1"
+    imported = secp256k1_private_key_from_hex(min_valid)
+    err_code = secp256k1_get_last_error()
+    expected = BN_hex2bn(min_valid)
+    If err_code = SECP256K1_OK And BN_cmp(imported.private_key, expected) = 0 Then
+        passed = passed + 1
+        Debug.Print "APROVADO: Importação de chave privada mínima válida"
+    Else
+        Debug.Print "FALHOU: Importação de chave privada mínima válida"
+    End If
+    total = total + 1
+
+    Dim zero_key As String
+    zero_key = String(64, "0")
+    imported = secp256k1_private_key_from_hex(zero_key)
+    err_code = secp256k1_get_last_error()
+    If err_code = SECP256K1_ERROR_INVALID_PRIVATE_KEY And BN_is_zero(imported.private_key) Then
+        passed = passed + 1
+        Debug.Print "APROVADO: Rejeição de importação para chave privada zero"
+    Else
+        Debug.Print "FALHOU: Rejeição de importação para chave privada zero"
+    End If
+    total = total + 1
+
+    Dim curve_order_hex As String
+    curve_order_hex = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141"
+    imported = secp256k1_private_key_from_hex(curve_order_hex)
+    err_code = secp256k1_get_last_error()
+    If err_code = SECP256K1_ERROR_INVALID_PRIVATE_KEY And BN_is_zero(imported.private_key) Then
+        passed = passed + 1
+        Debug.Print "APROVADO: Rejeição de importação para chave privada igual a n"
+    Else
+        Debug.Print "FALHOU: Rejeição de importação para chave privada igual a n"
+    End If
+    total = total + 1
+
+    Dim curve_order_plus_one As String
+    curve_order_plus_one = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364142"
+    imported = secp256k1_private_key_from_hex(curve_order_plus_one)
+    err_code = secp256k1_get_last_error()
+    If err_code = SECP256K1_ERROR_INVALID_PRIVATE_KEY And BN_is_zero(imported.private_key) Then
+        passed = passed + 1
+        Debug.Print "APROVADO: Rejeição de importação para chave privada maior que n"
+    Else
+        Debug.Print "FALHOU: Rejeição de importação para chave privada maior que n"
+    End If
+    total = total + 1
+
+    Dim max_valid As String
+    max_valid = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364140"
+    imported = secp256k1_private_key_from_hex(max_valid)
+    err_code = secp256k1_get_last_error()
+    expected = BN_hex2bn(max_valid)
+    If err_code = SECP256K1_OK And BN_cmp(imported.private_key, expected) = 0 Then
+        passed = passed + 1
+        Debug.Print "APROVADO: Importação de chave privada máxima válida"
+    Else
+        Debug.Print "FALHOU: Importação de chave privada máxima válida"
+    End If
+    total = total + 1
 End Sub
 
 ' Testa assinatura e verificação


### PR DESCRIPTION
## Summary
- validate imported private keys against the secp256k1 curve order before deriving points
- propagate invalid private key errors through the public API helper
- add boundary tests for importing private keys at 0, n, n+1, and neighboring valid values

## Testing
- not run (VBA test environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e06cc03b78833394dc5d671f012672