### PR TITLE
Ensure constant-time scalar multiplication respects security mode

### DIFF
--- a/src/EC_Endomorphism_GLV.bas
+++ b/src/EC_Endomorphism_GLV.bas
@@ -14,7 +14,12 @@ Private Const LAMBDA_HEX As String = "5363AD4CC05C30E0A5261C028812645A122E22EA20
 
 Public Function ec_point_mul_glv(ByRef result As EC_POINT, ByRef scalar As BIGNUM_TYPE, ByRef point As EC_POINT, ByRef ctx As SECP256K1_CTX) As Boolean
     ' Multiplicação escalar usando método GLV - 40-50% mais rápido
-    
+
+    If require_constant_time() Then
+        ec_point_mul_glv = ec_point_mul_ladder(result, scalar, point, ctx)
+        Exit Function
+    End If
+
     ' Decompor escalar: k = k1 + k2*λ onde |k1|,|k2| ≈ √n
     Dim k1 As BIGNUM_TYPE, k2 As BIGNUM_TYPE
     k1 = BN_new(): k2 = BN_new()

--- a/src/EC_Montgomery_Ladder.bas
+++ b/src/EC_Montgomery_Ladder.bas
@@ -5,10 +5,22 @@ Option Explicit
 ' MONTGOMERY LADDER - RESISTÊNCIA A TIMING ATTACKS
 ' =============================================================================
 
+Private ladder_call_counter As Long
+
+Public Sub reset_ladder_call_counter()
+    ladder_call_counter = 0
+End Sub
+
+Public Function get_ladder_call_counter() As Long
+    get_ladder_call_counter = ladder_call_counter
+End Function
+
 Public Function ec_point_mul_ladder(ByRef result As EC_POINT, ByRef scalar As BIGNUM_TYPE, ByRef point As EC_POINT, ByRef ctx As SECP256K1_CTX) As Boolean
     ' Multiplicação escalar resistente a timing attacks
     ' Sempre executa mesmo número de operações independente do escalar
-    
+
+    ladder_call_counter = ladder_call_counter + 1
+
     If BN_is_zero(scalar) Or point.infinity Then
         Call ec_point_set_infinity(result)
         ec_point_mul_ladder = True

--- a/src/EC_Multiplication_Dispatch.bas
+++ b/src/EC_Multiplication_Dispatch.bas
@@ -29,6 +29,11 @@ Public Function ec_point_mul_ultimate(ByRef result As EC_POINT, ByRef scalar As 
     Dim scalar_bits As Long
     scalar_bits = BN_num_bits(scalar)
 
+    If require_constant_time() Then
+        ec_point_mul_ultimate = ec_point_mul_ladder(result, scalar, point, ctx)
+        Exit Function
+    End If
+
     If is_generator_point(point, ctx) Then
         If EC_Precomputed_Manager.use_precomputed_gen_tables() Then
             ec_point_mul_ultimate = ec_generator_mul_precomputed_naf(result, scalar, ctx)

--- a/src/EC_Optimizations_Advanced.bas
+++ b/src/EC_Optimizations_Advanced.bas
@@ -7,6 +7,11 @@ Option Explicit
 
 Public Function ec_point_mul_generator_optimized(ByRef result As EC_POINT, ByRef scalar As BIGNUM_TYPE, ByRef ctx As SECP256K1_CTX) As Boolean
     ' Multiplicação do gerador com seleção automática da melhor técnica
+    If require_constant_time() Then
+        ec_point_mul_generator_optimized = ec_point_mul_ladder(result, scalar, ctx.g, ctx)
+        Exit Function
+    End If
+
     If use_precomputed_gen_tables() Then
         ec_point_mul_generator_optimized = ec_generator_mul_precomputed_naf(result, scalar, ctx)
     Else
@@ -18,6 +23,11 @@ Public Function ec_generator_mul_precomputed_naf(ByRef result As EC_POINT, ByRef
     ' Multiplicação com Windowing NAF (Non-Adjacent Form) - 25% melhoria
     Const window_size As Long = 4
     Dim naf() As Long, i As Long, digit As Long
+
+    If require_constant_time() Then
+        ec_generator_mul_precomputed_naf = ec_point_mul_ladder(result, scalar, ctx.g, ctx)
+        Exit Function
+    End If
     
     ' Converter escalar para NAF
     Call scalar_to_naf(naf, scalar, window_size)

--- a/src/EC_Precomputed_Cache.bas
+++ b/src/EC_Precomputed_Cache.bas
@@ -17,7 +17,12 @@ Private cache_misses As Long
 
 Public Function ec_point_mul_cached(ByRef result As EC_POINT, ByRef scalar As BIGNUM_TYPE, ByRef point As EC_POINT, ByRef ctx As SECP256K1_CTX) As Boolean
     ' Multiplicação com cache dinâmico de múltiplos ímpares
-    
+
+    If require_constant_time() Then
+        ec_point_mul_cached = ec_point_mul_ladder(result, scalar, point, ctx)
+        Exit Function
+    End If
+
     If BN_is_zero(scalar) Or point.infinity Then
         Call ec_point_set_infinity(result)
         ec_point_mul_cached = True

--- a/src/EC_Precomputed_Manager.bas
+++ b/src/EC_Precomputed_Manager.bas
@@ -101,6 +101,11 @@ Public Function ec_generator_mul_fast(ByRef result As EC_POINT, ByRef scalar As 
     ' RETORNA:
     '   True se multiplicação foi bem-sucedida, False caso contrário
     ' -------------------------------------------------------------------------
+    If require_constant_time() Then
+        ec_generator_mul_fast = ec_point_mul_ladder(result, scalar, ctx.g, ctx)
+        Exit Function
+    End If
+
     ' Garantir que tabelas estejam inicializadas
     If Not precomputed_initialized Then
         If Not init_precomputed_tables() Then
@@ -133,6 +138,11 @@ Public Function ec_point_mul_fast(ByRef result As EC_POINT, ByRef scalar As BIGN
     ' RETORNA:
     '   True se multiplicação foi bem-sucedida, False caso contrário
     ' -------------------------------------------------------------------------
+    If require_constant_time() Then
+        ec_point_mul_fast = ec_point_mul_ladder(result, scalar, point, ctx)
+        Exit Function
+    End If
+
     ' Garantir que tabelas estejam inicializadas
     If Not precomputed_initialized Then
         If Not init_precomputed_tables() Then

--- a/src/EC_Sliding_Window_NAF.bas
+++ b/src/EC_Sliding_Window_NAF.bas
@@ -4,7 +4,12 @@ Option Explicit
 Public Function ec_point_mul_sliding_naf(ByRef result As EC_POINT, ByRef scalar As BIGNUM_TYPE, ByRef point As EC_POINT, ByRef ctx As SECP256K1_CTX) As Boolean
     ' Sliding Window NAF - 15-20% melhoria sobre NAF fixo
     Const max_window As Long = 6
-    
+
+    If require_constant_time() Then
+        ec_point_mul_sliding_naf = ec_point_mul_ladder(result, scalar, point, ctx)
+        Exit Function
+    End If
+
     If BN_is_zero(scalar) Or point.infinity Then
         Call ec_point_set_infinity(result)
         ec_point_mul_sliding_naf = True

--- a/src/EC_secp256k1_Arithmetic.bas
+++ b/src/EC_secp256k1_Arithmetic.bas
@@ -450,6 +450,11 @@ Public Function ec_point_mul_jacobian_optimized(ByRef result As EC_POINT, ByRef 
     ' VANTAGEM:
     '   Apenas 1 inversão modular (conversão final) vs N inversões (afim)
     ' -------------------------------------------------------------------------
+    If require_constant_time() Then
+        ec_point_mul_jacobian_optimized = ec_point_mul_ladder(result, scalar, point, ctx)
+        Exit Function
+    End If
+
     If BN_is_zero(scalar) Or point.infinity Then
         Call ec_point_set_infinity(result)
         ec_point_mul_jacobian_optimized = True

--- a/tests/Constant_Time_Dispatch_Tests.bas
+++ b/tests/Constant_Time_Dispatch_Tests.bas
@@ -1,0 +1,54 @@
+Attribute VB_Name = "Constant_Time_Dispatch_Tests"
+Option Explicit
+
+Public Sub Run_Constant_Time_Dispatch_Tests()
+    Debug.Print "=== Testes Constant-Time Dispatch ==="
+
+    Call secp256k1_init
+
+    Dim ctx As SECP256K1_CTX
+    ctx = secp256k1_context_create()
+
+    Dim scalar As BIGNUM_TYPE
+    scalar = BN_new()
+    Call BN_set_word(scalar, 12345&)
+
+    Dim result As EC_POINT
+    result = ec_point_new()
+
+    Dim arbitrary_point As EC_POINT
+    arbitrary_point = ec_point_new()
+    Call ec_point_double(arbitrary_point, ctx.g, ctx)
+
+    Call enable_security_mode
+    Call reset_ladder_call_counter
+
+    Dim before As Long
+    Dim after As Long
+
+    before = get_ladder_call_counter()
+    If Not ec_point_mul_ultimate(result, scalar, ctx.g, ctx) Then
+        Debug.Print "[ERRO] Multiplicação k*G falhou em modo seguro"
+    Else
+        after = get_ladder_call_counter()
+        If after - before = 1 Then
+            Debug.Print "[OK] k*G direcionado para Montgomery ladder"
+        Else
+            Debug.Print "[ERRO] k*G não passou pela Montgomery ladder (delta=" & (after - before) & ")"
+        End If
+    End If
+
+    before = get_ladder_call_counter()
+    If Not ec_point_mul_ultimate(result, scalar, arbitrary_point, ctx) Then
+        Debug.Print "[ERRO] Multiplicação k*P falhou em modo seguro"
+    Else
+        after = get_ladder_call_counter()
+        If after - before = 1 Then
+            Debug.Print "[OK] k*P direcionado para Montgomery ladder"
+        Else
+            Debug.Print "[ERRO] k*P não passou pela Montgomery ladder (delta=" & (after - before) & ")"
+        End If
+    End If
+
+    Call disable_security_mode
+End Sub


### PR DESCRIPTION
## Summary
- route ec_point_mul_ultimate through the Montgomery ladder whenever the security mode requires constant-time execution
- guard fast-path multiplication helpers so they delegate to the ladder when constant-time is enforced and add ladder call instrumentation
- add a diagnostic test that confirms both k·G and k·P use the ladder when security mode is enabled

## Testing
- Not run (VBA execution environment not available)


------
https://chatgpt.com/codex/tasks/task_e_68e07725e5d4833381c6d1abc83b6749