### PR TITLE
Implement constant-time Montgomery ladder cswap

### DIFF
--- a/src/EC_Montgomery_Ladder.bas
+++ b/src/EC_Montgomery_Ladder.bas
@@ -6,14 +6,103 @@ Option Explicit
 ' =============================================================================
 
 Private ladder_call_counter As Long
+Private ladder_iteration_counter As Long
+Private ladder_cswap_counter As Long
+Private ladder_bit_counts(0 To 1) As Long
 
 Public Sub reset_ladder_call_counter()
     ladder_call_counter = 0
+    ladder_iteration_counter = 0
+    ladder_cswap_counter = 0
+    ladder_bit_counts(0) = 0
+    ladder_bit_counts(1) = 0
 End Sub
 
 Public Function get_ladder_call_counter() As Long
     get_ladder_call_counter = ladder_call_counter
 End Function
+
+Public Function get_ladder_iteration_counter() As Long
+    get_ladder_iteration_counter = ladder_iteration_counter
+End Function
+
+Public Function get_ladder_cswap_counter() As Long
+    get_ladder_cswap_counter = ladder_cswap_counter
+End Function
+
+Public Function get_ladder_bit_count(ByVal bitValue As Long) As Long
+    If bitValue < 0 Or bitValue > 1 Then
+        get_ladder_bit_count = 0
+    Else
+        get_ladder_bit_count = ladder_bit_counts(bitValue)
+    End If
+End Function
+
+Private Sub bn_cswap(ByRef a As BIGNUM_TYPE, ByRef b As BIGNUM_TYPE, ByVal swap As Long)
+    Dim mask As Long
+    Dim i As Long
+    Dim maxWords As Long
+    Dim tmp As Long
+    Dim aNeg As Long, bNeg As Long
+    Dim aFlags As Long, bFlags As Long
+
+    mask = -CLng(swap And 1&)
+
+    maxWords = a.dmax
+    If b.dmax > maxWords Then maxWords = b.dmax
+    If maxWords < 1 Then maxWords = 1
+
+    Call bn_wexpand(a, maxWords)
+    Call bn_wexpand(b, maxWords)
+
+    For i = 0 To maxWords - 1
+        tmp = (a.d(i) Xor b.d(i)) And mask
+        a.d(i) = a.d(i) Xor tmp
+        b.d(i) = b.d(i) Xor tmp
+    Next i
+
+    tmp = (a.top Xor b.top) And mask
+    a.top = a.top Xor tmp
+    b.top = b.top Xor tmp
+
+    aNeg = a.neg
+    bNeg = b.neg
+    tmp = (aNeg Xor bNeg) And mask
+    aNeg = aNeg Xor tmp
+    bNeg = bNeg Xor tmp
+    a.neg = (aNeg <> 0)
+    b.neg = (bNeg <> 0)
+
+    aFlags = a.flags
+    bFlags = b.flags
+    tmp = (aFlags Xor bFlags) And mask
+    aFlags = aFlags Xor tmp
+    bFlags = bFlags Xor tmp
+    a.flags = aFlags
+    b.flags = bFlags
+End Sub
+
+Private Sub ec_point_cswap(ByRef a As EC_POINT, ByRef b As EC_POINT, ByVal swap As Long)
+    Dim mask As Long
+    Dim aInf As Long, bInf As Long
+    Dim tmp As Long
+
+    mask = -CLng(swap And 1&)
+
+    ladder_cswap_counter = ladder_cswap_counter + 1
+
+    Call bn_cswap(a.x, b.x, swap)
+    Call bn_cswap(a.y, b.y, swap)
+    Call bn_cswap(a.z, b.z, swap)
+
+    aInf = a.infinity
+    bInf = b.infinity
+    tmp = (aInf Xor bInf) And mask
+    aInf = aInf Xor tmp
+    bInf = bInf Xor tmp
+    a.infinity = (aInf <> 0)
+    b.infinity = (bInf <> 0)
+End Sub
 
 Public Function ec_point_mul_ladder(ByRef result As EC_POINT, ByRef scalar As BIGNUM_TYPE, ByRef point As EC_POINT, ByRef ctx As SECP256K1_CTX) As Boolean
     ' Multiplicação escalar resistente a timing attacks
@@ -35,23 +124,24 @@ Public Function ec_point_mul_ladder(ByRef result As EC_POINT, ByRef scalar As BI
     
     Dim i As Long, nbits As Long, bit As Long
     nbits = BN_num_bits(scalar)
-    
+
     For i = nbits - 1 To 0 Step -1
         bit = IIf(BN_is_bit_set(scalar, i), 1, 0)
-        
+
+        ladder_iteration_counter = ladder_iteration_counter + 1
+        ladder_bit_counts(bit) = ladder_bit_counts(bit) + 1
+
+        Call ec_point_cswap(R0, R1, bit)
+
         ' Sempre executar ambas operações (constant-time)
         Call ec_point_add(temp, R0, R1, ctx)
         Call ec_point_double(R1, R1, ctx)
         Call ec_point_double(R0, R0, ctx)
-        
-        ' Swap condicional baseado no bit
-        If bit = 1 Then
-            Call ec_point_copy(R0, temp)
-        Else
-            Call ec_point_copy(R1, temp)
-        End If
+        Call ec_point_copy(R1, temp)
+
+        Call ec_point_cswap(R0, R1, bit)
     Next i
-    
+
     Call ec_point_copy(result, R0)
     ec_point_mul_ladder = True
 End Function

--- a/tests/Constant_Time_Dispatch_Tests.bas
+++ b/tests/Constant_Time_Dispatch_Tests.bas
@@ -13,6 +13,11 @@ Public Sub Run_Constant_Time_Dispatch_Tests()
     scalar = BN_new()
     Call BN_set_word(scalar, 12345&)
 
+    Dim scalar_reg0 As BIGNUM_TYPE
+    Dim scalar_reg1 As BIGNUM_TYPE
+    scalar_reg0 = BN_hex2bn("A5")
+    scalar_reg1 = BN_hex2bn("9A")
+
     Dim result As EC_POINT
     result = ec_point_new()
 
@@ -47,6 +52,47 @@ Public Sub Run_Constant_Time_Dispatch_Tests()
             Debug.Print "[OK] k*P direcionado para Montgomery ladder"
         Else
             Debug.Print "[ERRO] k*P não passou pela Montgomery ladder (delta=" & (after - before) & ")"
+        End If
+    End If
+
+    Debug.Print "--- Regression: Montgomery ladder constant-time path instrumentation ---"
+
+    Dim iterRef As Long
+    Dim iterAlt As Long
+    Dim cswapRef As Long
+    Dim cswapAlt As Long
+    Dim zeroCount As Long
+    Dim oneCount As Long
+
+    Call reset_ladder_call_counter()
+    If Not ec_point_mul_ladder(result, scalar_reg0, ctx.g, ctx) Then
+        Debug.Print "[ERRO] Montgomery ladder falhou para escalar base"
+    Else
+        iterRef = get_ladder_iteration_counter()
+        cswapRef = get_ladder_cswap_counter()
+        zeroCount = get_ladder_bit_count(0)
+        oneCount = get_ladder_bit_count(1)
+
+        If zeroCount > 0 And oneCount > 0 Then
+            Debug.Print "[OK] Ladder executou caminhos de bit 0 e 1 (0s=" & zeroCount & ", 1s=" & oneCount & ")"
+        Else
+            Debug.Print "[ERRO] Ladder não percorreu ambos os caminhos de bits (0s=" & zeroCount & ", 1s=" & oneCount & ")"
+        End If
+    End If
+
+    Call reset_ladder_call_counter()
+    If Not ec_point_mul_ladder(result, scalar_reg1, ctx.g, ctx) Then
+        Debug.Print "[ERRO] Montgomery ladder falhou para escalar alternativa"
+    Else
+        iterAlt = get_ladder_iteration_counter()
+        cswapAlt = get_ladder_cswap_counter()
+
+        If iterRef = iterAlt And cswapRef = cswapAlt Then
+            Debug.Print "[OK] Contagem de iterações/cswap idêntica para escalares distintos " & _
+                        "(iter=" & iterAlt & ", cswap=" & cswapAlt & ")"
+        Else
+            Debug.Print "[ERRO] Contagens divergem: iterRef=" & iterRef & _
+                        ", iterAlt=" & iterAlt & ", csRef=" & cswapRef & ", csAlt=" & cswapAlt & ")"
         End If
     End If
 


### PR DESCRIPTION
## Summary
- add branch-free conditional swap helpers and execute them before/after each ladder step to enforce constant-time behaviour
- expose ladder iteration, swap, and per-bit counters for instrumentation
- extend constant-time dispatch tests with regression coverage that exercises both bit paths and verifies identical operation counts across scalars

## Testing
- not run (VBA runtime not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e07b6e2dec83338d06aec2101d8e33