### PR TITLE
Fix batch verify expected r accumulation

### DIFF
--- a/src/ECDSA_Batch_Verify.bas
+++ b/src/ECDSA_Batch_Verify.bas
@@ -48,11 +48,9 @@ Public Function ecdsa_batch_verify(ByRef signatures() As BATCH_SIGNATURE, ByRef 
     
     For i = LBound(signatures) To UBound(signatures)
         Dim sinv As BIGNUM_TYPE, temp1 As BIGNUM_TYPE, temp2 As BIGNUM_TYPE
-        Dim coeff_r As BIGNUM_TYPE
         Dim z As BIGNUM_TYPE, point_contrib As EC_POINT
-        
+
         sinv = BN_new(): temp1 = BN_new(): temp2 = BN_new()
-        coeff_r = BN_new()
         z = BN_hex2bn(signatures(i).message_hash)
         point_contrib = ec_point_new()
         
@@ -70,9 +68,8 @@ Public Function ecdsa_batch_verify(ByRef signatures() As BATCH_SIGNATURE, ByRef 
         Call ec_point_mul(point_contrib, temp2, signatures(i).public_key, ctx)
         Call ec_point_add(sum_s2, sum_s2, point_contrib, ctx)
 
-        ' Acumular Σ(ai * ri) mod n para validar componente r
-        Call BN_mod_mul(coeff_r, coeffs(i), signatures(i).signature.r, ctx.n)
-        Call BN_mod_add(expected_r, expected_r, coeff_r, ctx.n)
+        ' Acumular Σ(ai * si^-1 * ri) mod n para validar componente r
+        Call BN_mod_add(expected_r, expected_r, temp2, ctx.n)
     Next i
     
     ' Calcular resultado final: sum_s1 * G + sum_s2

--- a/tests/Test_ECDSA_Batch_Verify.bas
+++ b/tests/Test_ECDSA_Batch_Verify.bas
@@ -50,6 +50,10 @@ Public Sub test_ecdsa_batch_verify_invalid_batches()
     Dim valid_result As Boolean
     valid_result = ecdsa_batch_verify(batch, ctx)
     Debug.Print "Lote válido aceito: ", valid_result
+    If Not valid_result Then
+        Err.Raise vbObjectError + &H2100&, "test_ecdsa_batch_verify_invalid_batches", _
+                  "Falha: lote de assinaturas válidas foi rejeitado pela verificação em lote."
+    End If
 
     Dim one As BIGNUM_TYPE
     one = BN_new()
@@ -66,6 +70,10 @@ Public Sub test_ecdsa_batch_verify_invalid_batches()
     Dim tampered_result As Boolean
     tampered_result = ecdsa_batch_verify(batch, ctx)
     Debug.Print "Lote com assinatura adulterada aceito: ", tampered_result
+    If tampered_result Then
+        Err.Raise vbObjectError + &H2101&, "test_ecdsa_batch_verify_invalid_batches", _
+                  "Falha: lote com assinatura adulterada foi aceito pela verificação em lote."
+    End If
 
     ' Segundo cenário: hash da mensagem não corresponde à assinatura
     Dim mismatch_batch(0 To 0) As BATCH_SIGNATURE
@@ -80,6 +88,10 @@ Public Sub test_ecdsa_batch_verify_invalid_batches()
     Dim mismatch_result As Boolean
     mismatch_result = ecdsa_batch_verify(mismatch_batch, ctx)
     Debug.Print "Lote com hash divergente aceito: ", mismatch_result
+    If mismatch_result Then
+        Err.Raise vbObjectError + &H2102&, "test_ecdsa_batch_verify_invalid_batches", _
+                  "Falha: lote com hash divergente foi aceito pela verificação em lote."
+    End If
 
     Debug.Print "--- RESUMO ---"
     Debug.Print "Validação lote válido: ", IIf(valid_result, "OK", "ERRO")


### PR DESCRIPTION
## Summary
- reuse the precomputed ai·si^{-1}·ri factor when building the expected r sum in batch verification
- remove the redundant coefficient variable and tighten the accompanying comment
- strengthen the batch verification test to assert valid batches succeed and tampered ones fail

## Testing
- not run (VBA environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e07d8b32188333955ff47a4de58dc5