### PR TITLE
Ensure batch verifier rejects invalid batch signatures

### DIFF
--- a/src/ECDSA_Batch_Verify.bas
+++ b/src/ECDSA_Batch_Verify.bas
@@ -53,10 +53,18 @@ Public Function ecdsa_batch_verify(ByRef signatures() As BATCH_SIGNATURE, ByRef 
         sinv = BN_new(): temp1 = BN_new(): temp2 = BN_new()
         z = BN_hex2bn(signatures(i).message_hash)
         point_contrib = ec_point_new()
-        
+
+        If Not ecdsa_signature_is_valid(signatures(i).signature, ctx) Then
+            ecdsa_batch_verify = False
+            Exit Function
+        End If
+
         ' si^-1
-        Call BN_mod_inverse(sinv, signatures(i).signature.s, ctx.n)
-        
+        If Not BN_mod_inverse(sinv, signatures(i).signature.s, ctx.n) Then
+            ecdsa_batch_verify = False
+            Exit Function
+        End If
+
         ' ai * si^-1 * zi para soma do gerador
         Call BN_mod_mul(temp1, coeffs(i), sinv, ctx.n)
         Call BN_mod_mul(temp1, temp1, z, ctx.n)


### PR DESCRIPTION
## Summary
- add a shared helper to validate ECDSA signature scalars
- reuse the helper in single and batch verification and abort on inverse failure
- add regression coverage to ensure batch verification rejects signatures with s = 0

## Testing
- not run (Visual Basic 6 test harness not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e08556579c83338624786a50e13073