### PR TITLE
Harden constant-time swap instrumentation

### DIFF
--- a/src/BigInt_ConstTime.bas
+++ b/src/BigInt_ConstTime.bas
@@ -16,42 +16,8 @@ Option Base 0
 ' =============================================================================
 
 Public Function BN_consttime_swap_flag(ByVal condition As Long, ByRef a As BIGNUM_TYPE, ByRef b As BIGNUM_TYPE) As Boolean
-    ' Troca a e b se condition != 0, de forma resistente a timing attacks
-    ' Parâmetros: condition - condição de troca, a e b - BIGNUM a serem trocados
-    ' Algoritmo: usa máscara bit para evitar branches condicionais
-    ' Tempo de execução independente do valor de condition
-    Dim mask As Long, i As Long, max_len As Long
-
-    ' Criar máscara bit: 0xFFFFFFFF se condition != 0, senão 0x00000000
-    ' Evita branches condicionais que poderiam vazar informações via timing
-    mask = 0 - (condition And 1)
-
-    ' Garantir que ambos BIGNUM tenham o mesmo tamanho para operação uniforme
-    max_len = IIf(a.dmax > b.dmax, a.dmax, b.dmax)
-    If Not bn_wexpand(a, max_len) Then BN_consttime_swap_flag = False : Exit Function
-    If Not bn_wexpand(b, max_len) Then BN_consttime_swap_flag = False : Exit Function
-
-    ' Trocar dados dos limbs usando operações XOR condicionais
-    ' Algoritmo: se mask = 0xFFFFFFFF, troca; se mask = 0x00000000, não troca
-    For i = 0 To max_len - 1
-        Dim temp As Long
-        temp = mask And (a.d(i) Xor b.d(i))  ' temp = diferença se trocar, 0 se não
-        a.d(i) = a.d(i) Xor temp             ' a = a XOR diferença
-        b.d(i) = b.d(i) Xor temp             ' b = b XOR diferença
-    Next i
-
-    ' Trocar metadados (top e neg) usando mesma técnica
-    Dim temp_top As Long
-    temp_top = mask And (a.top Xor b.top)
-    a.top = a.top Xor temp_top
-    b.top = b.top Xor temp_top
-
-    ' Trocar flags de sinal de forma constant-time
-    Dim neg_mask As Long
-    neg_mask = mask And (IIf(a.neg, 1, 0) Xor IIf(b.neg, 1, 0))
-    a.neg = ((IIf(a.neg, 1, 0) Xor neg_mask) <> 0)
-    b.neg = ((IIf(b.neg, 1, 0) Xor neg_mask) <> 0)
-
+    ' Encaminha para implementação principal em BigInt_VBA
+    Call BigInt_VBA.BN_consttime_swap_flag(condition, a, b)
     BN_consttime_swap_flag = True
 End Function
 
@@ -60,12 +26,8 @@ End Function
 ' =============================================================================
 
 Public Function BN_mod_exp_consttime(ByRef r As BIGNUM_TYPE, ByRef a As BIGNUM_TYPE, ByRef e As BIGNUM_TYPE, ByRef m As BIGNUM_TYPE) As Boolean
-    ' Exponenciação modular resistente a timing attacks
-    ' Parâmetros: r = a^e mod m
-    ' NOTA: Implementação simplificada - usa algoritmo regular
-    ' Para segurança máxima, deveria implementar ladder binário ou windowing constante
-
-    BN_mod_exp_consttime = BN_mod_exp(r, a, e, m)
+    ' Encaminha para implementação principal em BigInt_VBA para manter tempo constante
+    BN_mod_exp_consttime = BigInt_VBA.BN_mod_exp_consttime(r, a, e, m)
 End Function
 
 ' =============================================================================

--- a/tests/BigInt_ConstTime_Tests.bas
+++ b/tests/BigInt_ConstTime_Tests.bas
@@ -141,5 +141,40 @@ Public Sub Run_ConstTime_Tests()
     End If
     total = total + 1
 
+    ' Teste 6: Instrumentação garante swap sem divergência de tempo
+    a = BN_hex2bn("123456789ABCDEF")
+    m = BN_hex2bn("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F")
+    Dim eSparse As BIGNUM_TYPE, eDense As BIGNUM_TYPE
+    Dim rSparse As BIGNUM_TYPE, rDense As BIGNUM_TYPE
+    eSparse = BN_hex2bn("80000001")
+    eDense = BN_hex2bn("FFFFFFFF")
+    rSparse = BN_new(): rDense = BN_new()
+
+    Call BigInt_VBA.BN_consttime_swap_reset_instrumentation()
+    BigInt_VBA.ConstTimeSwapInstrumentationEnabled = True
+    Call BigInt_VBA.BN_mod_exp_consttime(rSparse, a, eSparse, m)
+    Dim swapCallsSparse As Long, swapLimbsSparse As Long
+    swapCallsSparse = BigInt_VBA.ConstTimeSwapInstrumentationCallCount
+    swapLimbsSparse = BigInt_VBA.ConstTimeSwapInstrumentationTotalLimbs
+    BigInt_VBA.ConstTimeSwapInstrumentationEnabled = False
+
+    Call BigInt_VBA.BN_consttime_swap_reset_instrumentation()
+    BigInt_VBA.ConstTimeSwapInstrumentationEnabled = True
+    Call BigInt_VBA.BN_mod_exp_consttime(rDense, a, eDense, m)
+    Dim swapCallsDense As Long, swapLimbsDense As Long
+    swapCallsDense = BigInt_VBA.ConstTimeSwapInstrumentationCallCount
+    swapLimbsDense = BigInt_VBA.ConstTimeSwapInstrumentationTotalLimbs
+    BigInt_VBA.ConstTimeSwapInstrumentationEnabled = False
+
+    If swapCallsSparse = BN_num_bits(eSparse) _
+        And swapCallsSparse = swapCallsDense _
+        And swapLimbsSparse = swapLimbsDense Then
+        Debug.Print "APROVADO: Swap constant-time sem divergência por expoente"
+        passed = passed + 1
+    Else
+        Debug.Print "FALHOU: Swap constant-time sem divergência por expoente"
+    End If
+    total = total + 1
+
     Debug.Print "=== Testes Constant-Time: ", passed, "/", total, " aprovados ==="
 End Sub


### PR DESCRIPTION
## Summary
- replace BigInt_VBA.BN_consttime_swap_flag with a mask-based constant-time swap and add instrumentation counters
- delegate BigInt_ConstTime helpers to the updated BigInt_VBA implementations to avoid duplicate logic
- extend constant-time test suite with instrumentation coverage to ensure BN_mod_exp_consttime drives uniform swap execution

## Testing
- not run (VBA test harness not available)


------
https://chatgpt.com/codex/tasks/task_e_68e092405ad483339c1f90a2597bba57