### PR TITLE
Fix BN_mul_comba8 error handling and add regression coverage

### DIFF
--- a/src/BigInt_VBA.bas
+++ b/src/BigInt_VBA.bas
@@ -1213,15 +1213,15 @@ Private Function BN_mod_secp256k1_reduce_512(ByRef r As BIGNUM_TYPE, ByRef a As 
     Dim multiplier As BIGNUM_TYPE
     multiplier = BN_hex2bn("100000000000003D1")  ' 2^32 + 977
     
-    Call BN_mul(temp, high, multiplier)
-    Call BN_add(r, low, temp)
+    If Not BN_mul(temp, high, multiplier) Then BN_mod_secp256k1_reduce_512 = False : Exit Function
+    If Not BN_add(r, low, temp) Then BN_mod_secp256k1_reduce_512 = False : Exit Function
     
     ' Verificar se ainda precisa reduzir
     Dim secp256k1_p As BIGNUM_TYPE
     secp256k1_p = BN_hex2bn("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F")
     
     If BN_ucmp(r, secp256k1_p) >= 0 Then
-        Call BN_sub(r, r, secp256k1_p)
+        If Not BN_sub(r, r, secp256k1_p) Then BN_mod_secp256k1_reduce_512 = False : Exit Function
     End If
     
     BN_mod_secp256k1_reduce_512 = True
@@ -1229,4 +1229,5 @@ End Function
 Public Function BN_mul_comba8(ByRef r As BIGNUM_TYPE, ByRef a As BIGNUM_TYPE, ByRef b As BIGNUM_TYPE) As Boolean
     ' Multiplicação COMBA 8x8 limbs para operações secp256k1 (256-bit)
     ' Alias para BN_mul_fast256 - mantém compatibilidade com chamadas existentes
+    BN_mul_comba8 = BigInt_Comba.BN_mul_fast256(r, a, b)
 End Function

--- a/src/EC_secp256k1_Arithmetic.bas
+++ b/src/EC_secp256k1_Arithmetic.bas
@@ -71,14 +71,12 @@ Public Function ec_point_add(ByRef result As EC_POINT, ByRef a As EC_POINT, ByRe
 
     ' Tratar casos de infinito (elemento neutro)
     If a.infinity Then
-        Call ec_point_copy(result, b)
-        ec_point_add = True
+        ec_point_add = ec_point_copy(result, b)
         Exit Function
     End If
 
     If b.infinity Then
-        Call ec_point_copy(result, a)
-        ec_point_add = True
+        ec_point_add = ec_point_copy(result, a)
         Exit Function
     End If
 
@@ -106,28 +104,27 @@ Public Function ec_point_add(ByRef result As EC_POINT, ByRef a As EC_POINT, ByRe
     dx = BN_new() : dy = BN_new() : dx_inv = BN_new()
 
     ' Calcular diferença das coordenadas x
-    Call BN_mod_sub(dx, b.x, a.x, ctx.p)
+    If Not BN_mod_sub(dx, b.x, a.x, ctx.p) Then ec_point_add = False : Exit Function
 
     ' Calcular diferença das coordenadas y
-    Call BN_mod_sub(dy, b.y, a.y, ctx.p)
+    If Not BN_mod_sub(dy, b.y, a.y, ctx.p) Then ec_point_add = False : Exit Function
 
     ' Calcular inclinação da reta secante
     If Not BN_mod_inverse(dx_inv, dx, ctx.p) Then ec_point_add = False : Exit Function
-    Call BN_mod_mul(lambda, dy, dx_inv, ctx.p)
+    If Not BN_mod_mul(lambda, dy, dx_inv, ctx.p) Then ec_point_add = False : Exit Function
 
     ' Calcular coordenada x do ponto resultante
-    Call BN_mod_sqr(x3, lambda, ctx.p)
-    Call BN_mod_sub(x3, x3, a.x, ctx.p)
-    Call BN_mod_sub(x3, x3, b.x, ctx.p)
+    If Not BN_mod_sqr(x3, lambda, ctx.p) Then ec_point_add = False : Exit Function
+    If Not BN_mod_sub(x3, x3, a.x, ctx.p) Then ec_point_add = False : Exit Function
+    If Not BN_mod_sub(x3, x3, b.x, ctx.p) Then ec_point_add = False : Exit Function
 
     ' Calcular coordenada y do ponto resultante
     Dim temp As BIGNUM_TYPE : temp = BN_new()
-    Call BN_mod_sub(temp, a.x, x3, ctx.p)
-    Call BN_mod_mul(y3, lambda, temp, ctx.p)
-    Call BN_mod_sub(y3, y3, a.y, ctx.p)
+    If Not BN_mod_sub(temp, a.x, x3, ctx.p) Then ec_point_add = False : Exit Function
+    If Not BN_mod_mul(y3, lambda, temp, ctx.p) Then ec_point_add = False : Exit Function
+    If Not BN_mod_sub(y3, y3, a.y, ctx.p) Then ec_point_add = False : Exit Function
 
-    Call ec_point_set_affine(result, x3, y3)
-    ec_point_add = True
+    ec_point_add = ec_point_set_affine(result, x3, y3)
 End Function
 
 ' =============================================================================
@@ -183,31 +180,30 @@ Public Function ec_point_double(ByRef result As EC_POINT, ByRef a As EC_POINT, B
     numerator = BN_new() : denominator = BN_new() : denom_inv = BN_new()
 
     ' Calcular numerador: 3x²
-    Call BN_mod_sqr(numerator, a.x, ctx.p)  ' numerator = x²
+    If Not BN_mod_sqr(numerator, a.x, ctx.p) Then ec_point_double = False : Exit Function  ' numerator = x²
     Dim three As BIGNUM_TYPE : three = BN_new() : Call BN_set_word(three, 3)
-    Call BN_mod_mul(numerator, numerator, three, ctx.p)
+    If Not BN_mod_mul(numerator, numerator, three, ctx.p) Then ec_point_double = False : Exit Function
 
     ' Calcular denominador: 2y
     Dim two As BIGNUM_TYPE : two = BN_new() : Call BN_set_word(two, 2)
-    Call BN_mod_mul(denominator, two, a.y, ctx.p)
+    If Not BN_mod_mul(denominator, two, a.y, ctx.p) Then ec_point_double = False : Exit Function
 
     ' Calcular inclinação da reta tangente
     If Not BN_mod_inverse(denom_inv, denominator, ctx.p) Then ec_point_double = False : Exit Function
-    Call BN_mod_mul(lambda, numerator, denom_inv, ctx.p)
+    If Not BN_mod_mul(lambda, numerator, denom_inv, ctx.p) Then ec_point_double = False : Exit Function
 
     ' Calcular coordenada x do ponto duplicado
-    Call BN_mod_sqr(x3, lambda, ctx.p)
-    Call BN_mod_mul(denominator, two, a.x, ctx.p)  ' Reutilizar denominador para 2x
-    Call BN_mod_sub(x3, x3, denominator, ctx.p)
+    If Not BN_mod_sqr(x3, lambda, ctx.p) Then ec_point_double = False : Exit Function
+    If Not BN_mod_mul(denominator, two, a.x, ctx.p) Then ec_point_double = False : Exit Function  ' Reutilizar denominador para 2x
+    If Not BN_mod_sub(x3, x3, denominator, ctx.p) Then ec_point_double = False : Exit Function
 
     ' Calcular coordenada y do ponto duplicado
     Dim temp As BIGNUM_TYPE : temp = BN_new()
-    Call BN_mod_sub(temp, a.x, x3, ctx.p)
-    Call BN_mod_mul(y3, lambda, temp, ctx.p)
-    Call BN_mod_sub(y3, y3, a.y, ctx.p)
+    If Not BN_mod_sub(temp, a.x, x3, ctx.p) Then ec_point_double = False : Exit Function
+    If Not BN_mod_mul(y3, lambda, temp, ctx.p) Then ec_point_double = False : Exit Function
+    If Not BN_mod_sub(y3, y3, a.y, ctx.p) Then ec_point_double = False : Exit Function
 
-    Call ec_point_set_affine(result, x3, y3)
-    ec_point_double = True
+    ec_point_double = ec_point_set_affine(result, x3, y3)
 End Function
 
 ' =============================================================================

--- a/tests/BigInt_Regression_Tests.bas
+++ b/tests/BigInt_Regression_Tests.bas
@@ -79,12 +79,53 @@ Public Sub Run_Regression_Tests()
     ' Teste 5: Casos extremos de condições limite
     Call Test_Boundary_Edge_Cases(passed, total)
 
+    ' Teste 6: Regressões BN_mul/BN_mod_mul 256-bit
+    Call Test_BN_Mul_ModMul_Regression(passed, total)
+
     Debug.Print "=== TESTES DE REGRESSÃO: ", passed, "/", total, " APROVADOS ==="
     If passed = total Then
         Debug.Print "*** NENHUMA REGRESSÃO DETECTADA ***"
     Else
         Debug.Print "*** CRÍTICO: REGRESSÃO DETECTADA ***"
     End If
+End Sub
+
+' Testa regressões relacionadas à multiplicação 256-bit e redução modular
+Private Sub Test_BN_Mul_ModMul_Regression(ByRef passed As Long, ByRef total As Long)
+    Debug.Print "Testando regressões BN_mul/BN_mod_mul 256-bit..."
+
+    Dim a As BIGNUM_TYPE, b As BIGNUM_TYPE
+    Dim result_mul As BIGNUM_TYPE, expected_mul As BIGNUM_TYPE
+    Dim modulus As BIGNUM_TYPE, result_mod As BIGNUM_TYPE, expected_mod As BIGNUM_TYPE
+
+    a = BN_hex2bn("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE")
+    b = BN_hex2bn("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB")
+    result_mul = BN_new()
+    expected_mul = BN_hex2bn("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+
+    If BN_mul(result_mul, a, b) And BN_cmp(result_mul, expected_mul) = 0 Then
+        passed = passed + 1
+        Debug.Print "APROVADO: BN_mul 256-bit combina com resultado esperado"
+    Else
+        Debug.Print "FALHOU: BN_mul 256-bit incorreto"
+        Debug.Print "  Obtido: ", BN_bn2hex(result_mul)
+        Debug.Print "  Esperado: ", BN_bn2hex(expected_mul)
+    End If
+    total = total + 1
+
+    modulus = BN_hex2bn("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F")
+    result_mod = BN_new()
+    expected_mod = BN_hex2bn("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB55555A6A555F04B9")
+
+    If BN_mod_mul(result_mod, a, b, modulus) And BN_cmp(result_mod, expected_mod) = 0 Then
+        passed = passed + 1
+        Debug.Print "APROVADO: BN_mod_mul 256-bit reduz corretamente"
+    Else
+        Debug.Print "FALHOU: BN_mod_mul 256-bit incorreto"
+        Debug.Print "  Obtido: ", BN_bn2hex(result_mod)
+        Debug.Print "  Esperado: ", BN_bn2hex(expected_mod)
+    End If
+    total = total + 1
 End Sub
 
 ' Testa regressão do bug de identidade de divisão

--- a/tests/EC_secp256k1_Tests.bas
+++ b/tests/EC_secp256k1_Tests.bas
@@ -199,6 +199,29 @@ Public Sub Run_EC_Secp256k1_Tests()
         Debug.Print "FALHOU: Multiplicação windowed consistente com double-and-add"
     End If
 
+    ' Teste 9: Regressão adição de pontos 256-bit (G + G = 2G)
+    Dim ctx_reg As SECP256K1_CTX: ctx_reg = secp256k1_context_create()
+    Dim g1 As EC_POINT, g2 As EC_POINT, sum_point As EC_POINT, expected_2g As EC_POINT
+    g1 = ec_point_new(): g2 = ec_point_new(): sum_point = ec_point_new(): expected_2g = ec_point_new()
+    Call ec_point_copy(g1, ctx_reg.g)
+    Call ec_point_copy(g2, ctx_reg.g)
+    expected_2g.x = BN_hex2bn("C6047F9441ED7D6D3045406E95C07CD85C778E4B8CEF3CA7ABAC09B95C709EE5")
+    expected_2g.y = BN_hex2bn("1AE168FEA63DC339A3C58419466CEAEEF7F632653266D0E1236431A950CFE52A")
+
+    total = total + 1
+    If ec_point_add(sum_point, g1, g2, ctx_reg) Then
+        If BN_cmp(sum_point.x, expected_2g.x) = 0 And BN_cmp(sum_point.y, expected_2g.y) = 0 Then
+            Debug.Print "APROVADO: ec_point_add produz 2G esperado"
+            passed = passed + 1
+        Else
+            Debug.Print "FALHOU: ec_point_add resultou em coordenadas incorretas"
+            Debug.Print "  x: ", BN_bn2hex(sum_point.x)
+            Debug.Print "  y: ", BN_bn2hex(sum_point.y)
+        End If
+    Else
+        Debug.Print "FALHOU: ec_point_add retornou erro"
+    End If
+
     Debug.Print "=== Testes EC secp256k1: ", passed, "/", total, " aprovados ==="
 
     If passed = total Then


### PR DESCRIPTION
## Summary
- wire the BN_mul_comba8 stub to the optimized BigInt_Comba implementation and propagate failures during secp256k1 reduction
- harden ec_point_add and ec_point_double so modular helpers must succeed before continuing
- add regression checks for 256-bit BN_mul/BN_mod_mul and a G+G point addition case

## Testing
- not run (VBA test harness not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e09abe5fa0833392bf353975805734