### PR TITLE
Implement RFC6979 retries for signer

### DIFF
--- a/tests/Test_RFC6979_Rejection.bas
+++ b/tests/Test_RFC6979_Rejection.bas
@@ -52,3 +52,44 @@ Public Sub test_rfc6979_rejection()
 
     Debug.Print "=== TESTE RFC6979 CONCLUÍDO ==="
 End Sub
+
+Public Sub test_rfc6979_sign_retry()
+    Debug.Print "=== TESTE RFC6979 SIGN RETRY ==="
+
+    Call secp256k1_init
+
+    ' Forçar que a primeira tentativa de assinatura falhe após o cálculo de r
+    EC_secp256k1_ECDSA.RFC6979_Test_ForceRetryCount = 1
+
+    Dim message As String
+    message = "Regression test forcing signing retry"
+
+    Dim message_hash As String
+    message_hash = SHA256_VBA.SHA256_String(message)
+
+    Dim private_key As String
+    private_key = "C9AFA9D845BA75166B5C215767B1D6934E50C3DB36E89B127B8A622B120F6721"
+
+    Dim signature As String
+    signature = secp256k1_sign(message_hash, private_key)
+
+    Debug.Print "Rejeições durante retry: " & EC_secp256k1_ECDSA.RFC6979_Test_Rejections
+    Debug.Print "Assinatura gerada após retry: " & (signature <> "")
+
+    If EC_secp256k1_ECDSA.RFC6979_Test_Rejections < 1 Then
+        Err.Raise vbObjectError + &H2002&, "test_rfc6979_sign_retry", _
+                  "Nenhum retry foi registrado durante o teste."
+    End If
+
+    If signature = "" Then
+        Err.Raise vbObjectError + &H2003&, "test_rfc6979_sign_retry", _
+                  "Assinatura vazia após forçar retry da primeira tentativa."
+    End If
+
+    ' Restaurar estado dos ganchos de teste
+    EC_secp256k1_ECDSA.RFC6979_Test_ForceRetryCount = 0
+    EC_secp256k1_ECDSA.RFC6979_Test_RejectNextCandidates = 0
+    EC_secp256k1_ECDSA.RFC6979_Test_Rejections = 0
+
+    Debug.Print "=== TESTE RFC6979 SIGN RETRY CONCLUÍDO ==="
+End Sub


### PR DESCRIPTION
## Summary
- update the deterministic signer to keep requesting RFC6979 candidates until inversion succeeds and both r and s are non-zero
- factor RFC6979 state management into reusable helpers and expose a test hook for retry scenarios
- extend the RFC6979 regression suite with a deterministic retry test that confirms the signer loops

## Testing
- not run (VBA automation not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e11dbf1f64833397f0e53cb3d737a8