### PR TITLE
Rewrite constant-time modular inverse implementation

### DIFF
--- a/src/BigInt_ConstTime.bas
+++ b/src/BigInt_ConstTime.bas
@@ -40,69 +40,174 @@ Public Function BN_mod_inverse_consttime(ByRef r As BIGNUM_TYPE, ByRef a As BIGN
     ' Algoritmo: Euclides estendido binário com número fixo de iterações
     ' Tempo de execução independente dos valores de entrada
 
-    ' Validar que módulo é ímpar (requisito do algoritmo)
-    If Not BN_is_odd(n) Then BN_mod_inverse_consttime = False : Exit Function
+    ' Implementação constant-time do algoritmo binário de Euclides para inverso modular
+    ' Sempre executa 2 * BN_num_bits(n) iterações e utiliza swaps mascarados
 
-    ' Inicializar variáveis do algoritmo de Euclides estendido
+    If Not BN_is_odd(n) Then
+        BN_mod_inverse_consttime = False
+        Exit Function
+    End If
+
     Dim u As BIGNUM_TYPE, v As BIGNUM_TYPE, x1 As BIGNUM_TYPE, x2 As BIGNUM_TYPE
-    u = BN_new() : v = BN_new() : x1 = BN_new() : x2 = BN_new()
+    Dim u_base As BIGNUM_TYPE, v_base As BIGNUM_TYPE, x1_base As BIGNUM_TYPE, x2_base As BIGNUM_TYPE
+    Dim u_case_u_even As BIGNUM_TYPE, v_case_u_even As BIGNUM_TYPE, x1_case_u_even As BIGNUM_TYPE, x2_case_u_even As BIGNUM_TYPE
+    Dim u_case_v_even As BIGNUM_TYPE, v_case_v_even As BIGNUM_TYPE, x1_case_v_even As BIGNUM_TYPE, x2_case_v_even As BIGNUM_TYPE
+    Dim u_case_sub_uv As BIGNUM_TYPE, v_case_sub_uv As BIGNUM_TYPE, x1_case_sub_uv As BIGNUM_TYPE, x2_case_sub_uv As BIGNUM_TYPE
+    Dim u_case_sub_vu As BIGNUM_TYPE, v_case_sub_vu As BIGNUM_TYPE, x1_case_sub_vu As BIGNUM_TYPE, x2_case_sub_vu As BIGNUM_TYPE
+    Dim tmpA As BIGNUM_TYPE, tmpB As BIGNUM_TYPE, tmpC As BIGNUM_TYPE, tmpD As BIGNUM_TYPE
 
-    Call BN_mod(u, a, n)    ' u = a mod n
-    Call BN_copy(v, n)      ' v = n
-    Call BN_set_word(x1, 1) ' x1 = 1
-    BN_zero x2              ' x2 = 0
+    u = BN_new(): v = BN_new(): x1 = BN_new(): x2 = BN_new()
+    u_base = BN_new(): v_base = BN_new(): x1_base = BN_new(): x2_base = BN_new()
+    u_case_u_even = BN_new(): v_case_u_even = BN_new(): x1_case_u_even = BN_new(): x2_case_u_even = BN_new()
+    u_case_v_even = BN_new(): v_case_v_even = BN_new(): x1_case_v_even = BN_new(): x2_case_v_even = BN_new()
+    u_case_sub_uv = BN_new(): v_case_sub_uv = BN_new(): x1_case_sub_uv = BN_new(): x2_case_sub_uv = BN_new()
+    u_case_sub_vu = BN_new(): v_case_sub_vu = BN_new(): x1_case_sub_vu = BN_new(): x2_case_sub_vu = BN_new()
+    tmpA = BN_new(): tmpB = BN_new(): tmpC = BN_new(): tmpD = BN_new()
 
-    ' Executar número fixo de iterações para garantir tempo constante
-    ' Máximo teórico: 2 * bits do módulo (pior caso do algoritmo)
-    Dim iterations As Long, max_iterations As Long
+    Call BN_mod(u, a, n)
+    Call BN_copy(v, n)
+    Call BN_set_word(x1, 1)
+    BN_zero x2
+
+    Dim max_iterations As Long
+    Dim iter As Long
+    Dim swapCount As Long
     max_iterations = 2 * BN_num_bits(n)
 
-    ' Loop principal com número determinístico de iterações
-    For iterations = 0 To max_iterations - 1
-        ' Avaliar condições sem criar branches que vazem informação
-        Dim u_even As Long, v_even As Long, u_ge_v As Long
-        u_even = IIf(BN_is_odd(u), 0, 1)        ' u é par?
-        v_even = IIf(BN_is_odd(v), 0, 1)        ' v é par?
-        u_ge_v = IIf(BN_ucmp(u, v) >= 0, 1, 0)  ' u >= v?
+    For iter = 0 To max_iterations - 1
+        Call BN_copy(u_base, u)
+        Call BN_copy(v_base, v)
+        Call BN_copy(x1_base, x1)
+        Call BN_copy(x2_base, x2)
 
-        ' Executar operações baseadas nas condições avaliadas
-        ' NOTA: Em implementação ideal, todas as operações seriam executadas
-        ' condicionalmente usando máscaras bit para evitar branches
-        If u_even Then
-            ' Caso u par: u = u/2, ajustar x1
-            Call BN_rshift(u, u, 1)
-            If BN_is_odd(x1) Then Call BN_add(x1, x1, n)
-            Call BN_rshift(x1, x1, 1)
-        ElseIf v_even Then
-            ' Caso v par: v = v/2, ajustar x2
-            Call BN_rshift(v, v, 1)
-            If BN_is_odd(x2) Then Call BN_add(x2, x2, n)
-            Call BN_rshift(x2, x2, 1)
-        ElseIf u_ge_v Then
-            ' Caso u >= v: u = u - v, x1 = x1 - x2
-            Call BN_usub(u, u, v)
-            Call BN_mod_sub(x1, x1, x2, n)
-        Else
-            ' Caso u < v: v = v - u, x2 = x2 - x1
-            Call BN_usub(v, v, u)
-            Call BN_mod_sub(x2, x2, x1, n)
-        End If
+        Dim u_is_odd As Long, v_is_odd As Long, x1_is_odd As Long, x2_is_odd As Long
+        Dim u_ge_v As Long
 
-        ' Verificar condições de término
-        ' NOTA: Em implementação totalmente constant-time, não deveria haver
-        ' saída antecipada, mas executar todas as iterações sempre
-        If BN_is_one(u) Then
-            Call BN_copy(r, x1)
-            BN_mod_inverse_consttime = True
-            Exit Function
-        End If
-        If BN_is_one(v) Then
-            Call BN_copy(r, x2)
-            BN_mod_inverse_consttime = True
-            Exit Function
-        End If
-    Next iterations
+        u_is_odd = 0 - (BN_is_odd(u_base) <> 0)
+        v_is_odd = 0 - (BN_is_odd(v_base) <> 0)
+        x1_is_odd = 0 - (BN_is_odd(x1_base) <> 0)
+        x2_is_odd = 0 - (BN_is_odd(x2_base) <> 0)
+        u_ge_v = 0 - (BN_ucmp(u_base, v_base) >= 0)
 
-    ' Falha: não encontrou inverso no número máximo de iterações
-    BN_mod_inverse_consttime = False
+        Dim mask_case1 As Long, mask_case2 As Long, mask_case3 As Long, mask_case4 As Long
+        mask_case1 = 1 - u_is_odd
+        mask_case2 = u_is_odd * (1 - v_is_odd)
+        mask_case3 = u_is_odd * v_is_odd * u_ge_v
+        mask_case4 = u_is_odd * v_is_odd * (1 - u_ge_v)
+
+        Call BN_copy(u_case_u_even, u_base)
+        Call BN_rshift(u_case_u_even, u_case_u_even, 1)
+        Call BN_copy(v_case_u_even, v_base)
+        Call BN_copy(x2_case_u_even, x2_base)
+
+        Call BN_copy(tmpA, x1_base)
+        Call BN_rshift(tmpA, tmpA, 1)
+        Call BN_copy(tmpB, x1_base)
+        Call BN_add(tmpB, tmpB, n)
+        Call BN_rshift(tmpB, tmpB, 1)
+        Call BN_copy(x1_case_u_even, tmpA)
+        Call BN_copy(tmpC, tmpB)
+        swapCount = swapCount + 1
+        Call BN_consttime_swap_flag(x1_is_odd, x1_case_u_even, tmpC)
+
+        Call BN_copy(u_case_v_even, u_base)
+        Call BN_copy(v_case_v_even, v_base)
+        Call BN_rshift(v_case_v_even, v_case_v_even, 1)
+        Call BN_copy(x1_case_v_even, x1_base)
+
+        Call BN_copy(tmpA, x2_base)
+        Call BN_rshift(tmpA, tmpA, 1)
+        Call BN_copy(tmpB, x2_base)
+        Call BN_add(tmpB, tmpB, n)
+        Call BN_rshift(tmpB, tmpB, 1)
+        Call BN_copy(x2_case_v_even, tmpA)
+        Call BN_copy(tmpC, tmpB)
+        swapCount = swapCount + 1
+        Call BN_consttime_swap_flag(x2_is_odd, x2_case_v_even, tmpC)
+
+        Call BN_copy(u_case_sub_uv, u_base)
+        Call BN_sub(u_case_sub_uv, u_case_sub_uv, v_base)
+        Call BN_copy(v_case_sub_uv, v_base)
+        Call BN_copy(x1_case_sub_uv, x1_base)
+        Call BN_sub(x1_case_sub_uv, x1_case_sub_uv, x2_base)
+        Call BN_copy(x2_case_sub_uv, x2_base)
+
+        Call BN_copy(u_case_sub_vu, u_base)
+        Call BN_copy(v_case_sub_vu, v_base)
+        Call BN_sub(v_case_sub_vu, v_case_sub_vu, u_base)
+        Call BN_copy(x1_case_sub_vu, x1_base)
+        Call BN_copy(x2_case_sub_vu, x2_base)
+        Call BN_sub(x2_case_sub_vu, x2_case_sub_vu, x1_base)
+
+        swapCount = swapCount + 1
+        Call BN_consttime_swap_flag(mask_case1, u, u_case_u_even)
+        swapCount = swapCount + 1
+        Call BN_consttime_swap_flag(mask_case1, v, v_case_u_even)
+        swapCount = swapCount + 1
+        Call BN_consttime_swap_flag(mask_case1, x1, x1_case_u_even)
+        swapCount = swapCount + 1
+        Call BN_consttime_swap_flag(mask_case1, x2, x2_case_u_even)
+
+        swapCount = swapCount + 1
+        Call BN_consttime_swap_flag(mask_case2, u, u_case_v_even)
+        swapCount = swapCount + 1
+        Call BN_consttime_swap_flag(mask_case2, v, v_case_v_even)
+        swapCount = swapCount + 1
+        Call BN_consttime_swap_flag(mask_case2, x1, x1_case_v_even)
+        swapCount = swapCount + 1
+        Call BN_consttime_swap_flag(mask_case2, x2, x2_case_v_even)
+
+        swapCount = swapCount + 1
+        Call BN_consttime_swap_flag(mask_case3, u, u_case_sub_uv)
+        swapCount = swapCount + 1
+        Call BN_consttime_swap_flag(mask_case3, v, v_case_sub_uv)
+        swapCount = swapCount + 1
+        Call BN_consttime_swap_flag(mask_case3, x1, x1_case_sub_uv)
+        swapCount = swapCount + 1
+        Call BN_consttime_swap_flag(mask_case3, x2, x2_case_sub_uv)
+
+        swapCount = swapCount + 1
+        Call BN_consttime_swap_flag(mask_case4, u, u_case_sub_vu)
+        swapCount = swapCount + 1
+        Call BN_consttime_swap_flag(mask_case4, v, v_case_sub_vu)
+        swapCount = swapCount + 1
+        Call BN_consttime_swap_flag(mask_case4, x1, x1_case_sub_vu)
+        swapCount = swapCount + 1
+        Call BN_consttime_swap_flag(mask_case4, x2, x2_case_sub_vu)
+    Next iter
+
+    Dim u_is_one As Long, v_is_one As Long
+    u_is_one = 0 - (BN_is_one(u) <> 0)
+    v_is_one = 0 - (BN_is_one(v) <> 0)
+
+    Call BN_copy(tmpA, x1)
+    Call BN_copy(tmpB, x2)
+    swapCount = swapCount + 1
+    Call BN_consttime_swap_flag(v_is_one, tmpA, tmpB)
+
+    Dim is_neg As Long
+    is_neg = 0 - (tmpA.neg <> 0)
+
+    Call BN_copy(tmpC, tmpA)
+    Call BN_copy(tmpD, tmpA)
+    Call BN_add(tmpD, tmpD, n)
+    swapCount = swapCount + 1
+    Call BN_consttime_swap_flag(is_neg, tmpC, tmpD)
+
+    Dim ge_n As Long
+    ge_n = 0 - (BN_ucmp(tmpC, n) >= 0)
+
+    Call BN_copy(tmpD, tmpC)
+    Call BN_sub(tmpD, tmpD, n)
+    swapCount = swapCount + 1
+    Call BN_consttime_swap_flag(ge_n, tmpC, tmpD)
+
+    Call BN_copy(r, tmpC)
+
+    If BigInt_VBA.ConstTimeInverseInstrumentationEnabled Then
+        BigInt_VBA.ConstTimeInverseIterationCount = max_iterations
+        BigInt_VBA.ConstTimeInverseSwapCalls = swapCount
+    End If
+
+    BN_mod_inverse_consttime = ((u_is_one Or v_is_one) <> 0)
 End Function

--- a/src/BigInt_VBA.bas
+++ b/src/BigInt_VBA.bas
@@ -41,11 +41,19 @@ Public ConstTimeSwapInstrumentationEnabled As Boolean
 Public ConstTimeSwapInstrumentationCallCount As Long
 Public ConstTimeSwapInstrumentationTotalLimbs As Long
 Public ConstTimeSwapInstrumentationLastMask As Long
+Public ConstTimeInverseInstrumentationEnabled As Boolean
+Public ConstTimeInverseIterationCount As Long
+Public ConstTimeInverseSwapCalls As Long
 
 Public Sub BN_consttime_swap_reset_instrumentation()
     ConstTimeSwapInstrumentationCallCount = 0
     ConstTimeSwapInstrumentationTotalLimbs = 0
     ConstTimeSwapInstrumentationLastMask = 0
+End Sub
+
+Public Sub BN_consttime_inverse_reset_instrumentation()
+    ConstTimeInverseIterationCount = 0
+    ConstTimeInverseSwapCalls = 0
 End Sub
 
 ' =============================================================================

--- a/tests/BigInt_ConstTime_Tests.bas
+++ b/tests/BigInt_ConstTime_Tests.bas
@@ -176,5 +176,40 @@ Public Sub Run_ConstTime_Tests()
     End If
     total = total + 1
 
+    ' Teste 7: Inversão constant-time executa contagem fixa de iterações
+    Dim invSparse As BIGNUM_TYPE, invDense As BIGNUM_TYPE
+    Dim iterSparse As Long, iterDense As Long
+    Dim swapInverseSparse As Long, swapInverseDense As Long
+    Dim expectedIterations As Long
+    Dim aAlt As BIGNUM_TYPE
+
+    invSparse = BN_new(): invDense = BN_new()
+    aAlt = BN_hex2bn("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2E")
+    expectedIterations = 2 * BN_num_bits(m)
+
+    Call BigInt_VBA.BN_consttime_inverse_reset_instrumentation()
+    BigInt_VBA.ConstTimeInverseInstrumentationEnabled = True
+    Call BN_mod_inverse_consttime(invSparse, a, m)
+    iterSparse = BigInt_VBA.ConstTimeInverseIterationCount
+    swapInverseSparse = BigInt_VBA.ConstTimeInverseSwapCalls
+    BigInt_VBA.ConstTimeInverseInstrumentationEnabled = False
+
+    Call BigInt_VBA.BN_consttime_inverse_reset_instrumentation()
+    BigInt_VBA.ConstTimeInverseInstrumentationEnabled = True
+    Call BN_mod_inverse_consttime(invDense, aAlt, m)
+    iterDense = BigInt_VBA.ConstTimeInverseIterationCount
+    swapInverseDense = BigInt_VBA.ConstTimeInverseSwapCalls
+    BigInt_VBA.ConstTimeInverseInstrumentationEnabled = False
+
+    If iterSparse = expectedIterations _
+        And iterDense = expectedIterations _
+        And swapInverseSparse = swapInverseDense Then
+        Debug.Print "APROVADO: Inversão constant-time com iterações uniformes"
+        passed = passed + 1
+    Else
+        Debug.Print "FALHOU: Inversão constant-time com iterações uniformes"
+    End If
+    total = total + 1
+
     Debug.Print "=== Testes Constant-Time: ", passed, "/", total, " aprovados ==="
 End Sub


### PR DESCRIPTION
## Summary
- rewrite `BN_mod_inverse_consttime` to follow a masked constant-time binary Euclid that always runs the full iteration budget
- add constant-time inverse instrumentation counters alongside existing swap metrics
- extend the constant-time test suite to assert uniform iteration and swap counts for modular inversion

## Testing
- not run (environment lacks a VBA runtime)


------
https://chatgpt.com/codex/tasks/task_e_68e12c35c2488333a0903d05978a4777