### PR TITLE
Implement generator wNAF lookup and regression tests

### DIFF
--- a/src/EC_Optimizations_Advanced.bas
+++ b/src/EC_Optimizations_Advanced.bas
@@ -20,51 +20,223 @@ Public Function ec_point_mul_generator_optimized(ByRef result As EC_POINT, ByRef
 End Function
 
 Public Function ec_generator_mul_precomputed_naf(ByRef result As EC_POINT, ByRef scalar As BIGNUM_TYPE, ByRef ctx As SECP256K1_CTX) As Boolean
-    ' Multiplicação com Windowing NAF (Non-Adjacent Form) - 25% melhoria
+    ' Multiplicação com Windowed Non-Adjacent Form baseada na tabela de 1760 entradas
     Const window_size As Long = 4
-    Dim naf() As Long, i As Long, digit As Long
+    Dim naf() As Long
+    Dim i As Long
 
     If require_constant_time() Then
         ec_generator_mul_precomputed_naf = ec_point_mul_ladder(result, scalar, ctx.g, ctx)
         Exit Function
     End If
-    
-    ' Converter escalar para NAF
+
     Call scalar_to_naf(naf, scalar, window_size)
-    
-    ' Usar tabelas pré-computadas com NAF
+
     Call ec_point_set_infinity(result)
-    
+
     For i = UBound(naf) To 0 Step -1
-        Call ec_point_double(result, result, ctx)
+        If Not ec_point_double(result, result, ctx) Then
+            ec_generator_mul_precomputed_naf = False
+            Exit Function
+        End If
+
+        Dim digit As Long
         digit = naf(i)
+
         If digit <> 0 Then
+            Dim tableIndex As Long
+            tableIndex = (Abs(digit) - 1) \ 2
+
             Dim precomp_point As EC_POINT
-            precomp_point = get_precomputed_point(Abs(digit), ctx)
-            If digit < 0 Then Call ec_point_negate(precomp_point, precomp_point, ctx)
-            Call ec_point_add(result, result, precomp_point, ctx)
+            precomp_point = get_precomputed_point(tableIndex, ctx)
+
+            If precomp_point.infinity Then
+                ec_generator_mul_precomputed_naf = False
+                Exit Function
+            End If
+
+            If digit < 0 Then
+                If Not ec_point_negate(precomp_point, precomp_point, ctx) Then
+                    ec_generator_mul_precomputed_naf = False
+                    Exit Function
+                End If
+            End If
+
+            If Not ec_point_add(result, result, precomp_point, ctx) Then
+                ec_generator_mul_precomputed_naf = False
+                Exit Function
+            End If
         End If
     Next i
-    
+
     ec_generator_mul_precomputed_naf = True
 End Function
 
 Private Sub scalar_to_naf(ByRef naf() As Long, ByRef scalar As BIGNUM_TYPE, ByVal w As Long)
-    ' Converte escalar para Non-Adjacent Form
-    Dim bits As Long, i As Long, bit As Long
-    bits = BN_num_bits(scalar)
-    ReDim naf(0 To bits)
-    
-    For i = 0 To bits - 1
-        If BN_is_bit_set(scalar, i) Then
-            naf(i) = 1
+    ' Converte escalar para wNAF com dígitos ímpares em [-2^{w-1}+1, 2^{w-1}-1]
+    Dim pow_w As Long: pow_w = CLng(2 ^ w)
+    Dim half_pow As Long: half_pow = pow_w \ 2
+
+    Dim k As BIGNUM_TYPE: k = BN_new()
+    Call BN_copy(k, scalar)
+
+    Dim was_negative As Boolean
+    was_negative = scalar.neg
+    k.neg = False
+
+    Dim remainder As BIGNUM_TYPE: remainder = BN_new()
+    Dim magnitude As BIGNUM_TYPE: magnitude = BN_new()
+    Dim twoPow As BIGNUM_TYPE: twoPow = BN_new()
+
+    If Not BN_set_word(twoPow, pow_w) Then GoTo wnaf_error
+
+    If BN_is_zero(k) Then
+        ReDim naf(0 To 0)
+        naf(0) = 0
+        GoTo wnaf_finish
+    End If
+
+    Dim maxDigits As Long
+    maxDigits = BN_num_bits(k) + w + 1
+    If maxDigits < 1 Then maxDigits = 1
+    ReDim naf(0 To maxDigits - 1)
+
+    Dim used As Long: used = 0
+
+    Do While Not BN_is_zero(k)
+        If used > UBound(naf) Then ReDim Preserve naf(0 To used)
+
+        Dim digit As Long
+
+        If BN_is_odd(k) Then
+            If Not BN_mod(remainder, k, twoPow) Then GoTo wnaf_error
+
+            If remainder.top > 0 Then
+                digit = remainder.d(0)
+            Else
+                digit = 0
+            End If
+
+            If digit >= half_pow Then digit = digit - pow_w
+
+            If (digit And 1) = 0 Then
+                If digit >= 0 Then
+                    digit = digit + 1 - pow_w
+                Else
+                    digit = digit - 1 + pow_w
+                End If
+            End If
+
+            naf(used) = digit
+
+            If digit > 0 Then
+                If Not BN_set_word(magnitude, digit) Then GoTo wnaf_error
+                If Not BN_sub(k, k, magnitude) Then GoTo wnaf_error
+            Else
+                If Not BN_set_word(magnitude, -digit) Then GoTo wnaf_error
+                If Not BN_add(k, k, magnitude) Then GoTo wnaf_error
+            End If
         Else
-            naf(i) = 0
+            naf(used) = 0
         End If
-    Next i
+
+        If Not BN_rshift(k, k, 1) Then GoTo wnaf_error
+        used = used + 1
+    Loop
+
+    If used = 0 Then
+        ReDim naf(0 To 0)
+        naf(0) = 0
+    Else
+        ReDim Preserve naf(0 To used - 1)
+    End If
+
+wnaf_finish:
+    If was_negative Then
+        Dim idx As Long
+        For idx = LBound(naf) To UBound(naf)
+            naf(idx) = -naf(idx)
+        Next idx
+    End If
+    Exit Sub
+
+wnaf_error:
+    ReDim naf(0 To 0)
+    naf(0) = 0
+    GoTo wnaf_finish
 End Sub
 
 Private Function get_precomputed_point(ByVal index As Long, ByRef ctx As SECP256K1_CTX) As EC_POINT
-    ' Retorna ponto pré-computado da tabela
-    get_precomputed_point = ctx.g ' Simplificado
+    Dim point As EC_POINT
+    point = ec_point_new()
+
+    If index < 0 Then
+        Call ec_point_set_infinity(point)
+        get_precomputed_point = point
+        Exit Function
+    End If
+
+    Dim entry As String
+    entry = get_precomputed_gen_point(index)
+
+    If Len(entry) = 0 Then
+        Call ec_point_set_infinity(point)
+        get_precomputed_point = point
+        Exit Function
+    End If
+
+    If Not decode_precomputed_entry(entry, point, ctx) Then
+        Call ec_point_set_infinity(point)
+    End If
+
+    get_precomputed_point = point
+End Function
+
+Private Function decode_precomputed_entry(ByVal entry As String, ByRef point As EC_POINT, ByRef ctx As SECP256K1_CTX) As Boolean
+    Dim coords() As String
+    coords = Split(entry, ",")
+
+    If UBound(coords) < 15 Then Exit Function
+
+    Dim x_hex As String
+    Dim y_hex As String
+    Dim i As Long
+
+    For i = 7 To 0 Step -1
+        x_hex = x_hex & normalize_word(coords(i))
+    Next i
+
+    For i = 7 To 0 Step -1
+        y_hex = y_hex & normalize_word(coords(i + 8))
+    Next i
+
+    On Error GoTo decode_error
+
+    point.x = BN_hex2bn(x_hex)
+    point.y = BN_hex2bn(y_hex)
+    Call BN_set_word(point.z, 1)
+    point.infinity = False
+
+    If Not ec_point_is_on_curve(point, ctx) Then GoTo decode_error
+
+    decode_precomputed_entry = True
+    On Error GoTo 0
+    Exit Function
+
+decode_error:
+    On Error GoTo 0
+    decode_precomputed_entry = False
+End Function
+
+Private Function normalize_word(ByVal wordHex As String) As String
+    Dim trimmed As String
+    trimmed = UCase$(Replace$(Trim$(wordHex), " ", ""))
+
+    If Len(trimmed) = 0 Then trimmed = "0"
+
+    If Len(trimmed) > 8 Then
+        trimmed = Right$(trimmed, 8)
+    End If
+
+    normalize_word = Right$("00000000" & trimmed, 8)
 End Function

--- a/tests/Test_Generator_wNAF.bas
+++ b/tests/Test_Generator_wNAF.bas
@@ -1,0 +1,196 @@
+Attribute VB_Name = "Test_Generator_wNAF"
+Option Explicit
+Option Compare Binary
+Option Base 0
+
+' =============================================================================
+' TESTES DE REGRESSÃO - MULTIPLICAÇÃO DO GERADOR COM WNAF PRÉ-COMPUTADO
+' =============================================================================
+'
+' OBJETIVOS:
+'   • Validar que ec_generator_mul_precomputed_naf produz o mesmo resultado
+'     que ec_point_mul para um conjunto amplo de escalares.
+'   • Garantir que a representação wNAF utilizada emprega dígitos fora de ±1
+'     e inclui dígitos negativos, confirmando o uso da tabela pré-computada.
+'
+Public Sub test_generator_wnaf_regression()
+    Debug.Print "=== TESTE WNAF PRECOMPUTED × MULTIPLICAÇÃO GENÉRICA ==="
+
+    Call secp256k1_init
+
+    Dim ctx As SECP256K1_CTX
+    ctx = secp256k1_context_create()
+
+    Dim scalars() As String
+    scalars = Array( _
+        "01", _
+        "03", _
+        "05", _
+        "09", _
+        "1D", _
+        "11223344556677889900AABBCCDDEEFF", _
+        "C9AFA9D845BA75166B5C215767B1D6934E50C3DB36E89B127B8A622B120F6721", _
+        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364140")
+
+    Dim totalChecks As Long: totalChecks = 0
+    Dim passedChecks As Long: passedChecks = 0
+    Dim idx As Long
+    Dim maxAbsDigit As Long: maxAbsDigit = 0
+    Dim sawNegativeDigit As Boolean: sawNegativeDigit = False
+
+    For idx = LBound(scalars) To UBound(scalars)
+        Dim scalar_bn As BIGNUM_TYPE
+        scalar_bn = BN_hex2bn(scalars(idx))
+
+        Dim nafDigits() As Long
+        nafDigits = compute_wnaf_digits_for_test(scalar_bn, 4)
+
+        Dim j As Long
+        For j = LBound(nafDigits) To UBound(nafDigits)
+            If Abs(nafDigits(j)) > maxAbsDigit Then maxAbsDigit = Abs(nafDigits(j))
+            If nafDigits(j) < 0 Then sawNegativeDigit = True
+        Next j
+
+        Dim result_opt As EC_POINT
+        Dim result_ref As EC_POINT
+        result_opt = ec_point_new()
+        result_ref = ec_point_new()
+
+        totalChecks = totalChecks + 1
+
+        If Not ec_generator_mul_precomputed_naf(result_opt, scalar_bn, ctx) Then
+            Debug.Print "✗ Falha na multiplicação otimizada para escalar " & scalars(idx)
+            GoTo next_scalar
+        End If
+
+        If Not ec_point_mul(result_ref, scalar_bn, ctx.g, ctx) Then
+            Debug.Print "✗ Falha na multiplicação de referência para escalar " & scalars(idx)
+            GoTo next_scalar
+        End If
+
+        If ec_point_cmp(result_opt, result_ref, ctx) = 0 Then
+            passedChecks = passedChecks + 1
+            Debug.Print "✓ Escalar " & scalars(idx) & " validado"
+        Else
+            Debug.Print "✗ Divergência entre caminhos para escalar " & scalars(idx)
+        End If
+
+next_scalar:
+        ' continuar testes mesmo após falhas
+    Next idx
+
+    totalChecks = totalChecks + 1
+    If maxAbsDigit > 1 Then
+        passedChecks = passedChecks + 1
+        Debug.Print "✓ Dígito máximo wNAF |d| = " & maxAbsDigit
+    Else
+        Debug.Print "✗ Nenhum dígito wNAF excedeu ±1 (|d|max = " & maxAbsDigit & ")"
+    End If
+
+    totalChecks = totalChecks + 1
+    If sawNegativeDigit Then
+        passedChecks = passedChecks + 1
+        Debug.Print "✓ Representação wNAF apresentou dígitos negativos"
+    Else
+        Debug.Print "✗ Representação wNAF não gerou dígitos negativos"
+    End If
+
+    Debug.Print "--- RESUMO: " & passedChecks & " / " & totalChecks & " verificações aprovadas ---"
+End Sub
+
+Private Function compute_wnaf_digits_for_test(ByRef scalar As BIGNUM_TYPE, ByVal window_size As Long) As Long()
+    Dim result() As Long
+
+    Dim pow_w As Long: pow_w = CLng(2 ^ window_size)
+    Dim half_pow As Long: half_pow = pow_w \ 2
+
+    Dim k As BIGNUM_TYPE: k = BN_new()
+    Call BN_copy(k, scalar)
+
+    Dim was_negative As Boolean
+    was_negative = scalar.neg
+    k.neg = False
+
+    Dim remainder As BIGNUM_TYPE: remainder = BN_new()
+    Dim magnitude As BIGNUM_TYPE: magnitude = BN_new()
+    Dim twoPow As BIGNUM_TYPE: twoPow = BN_new()
+
+    If Not BN_set_word(twoPow, pow_w) Then GoTo wnaf_error
+
+    If BN_is_zero(k) Then
+        ReDim result(0 To 0)
+        result(0) = 0
+        GoTo wnaf_finish
+    End If
+
+    Dim maxDigits As Long
+    maxDigits = BN_num_bits(k) + window_size + 1
+    If maxDigits < 1 Then maxDigits = 1
+    ReDim result(0 To maxDigits - 1)
+
+    Dim used As Long: used = 0
+
+    Do While Not BN_is_zero(k)
+        If used > UBound(result) Then ReDim Preserve result(0 To used)
+
+        Dim digit As Long
+
+        If BN_is_odd(k) Then
+            If Not BN_mod(remainder, k, twoPow) Then GoTo wnaf_error
+
+            If remainder.top > 0 Then
+                digit = remainder.d(0)
+            Else
+                digit = 0
+            End If
+
+            If digit >= half_pow Then digit = digit - pow_w
+
+            If (digit And 1) = 0 Then
+                If digit >= 0 Then
+                    digit = digit + 1 - pow_w
+                Else
+                    digit = digit - 1 + pow_w
+                End If
+            End If
+
+            result(used) = digit
+
+            If digit > 0 Then
+                If Not BN_set_word(magnitude, digit) Then GoTo wnaf_error
+                If Not BN_sub(k, k, magnitude) Then GoTo wnaf_error
+            Else
+                If Not BN_set_word(magnitude, -digit) Then GoTo wnaf_error
+                If Not BN_add(k, k, magnitude) Then GoTo wnaf_error
+            End If
+        Else
+            result(used) = 0
+        End If
+
+        If Not BN_rshift(k, k, 1) Then GoTo wnaf_error
+        used = used + 1
+    Loop
+
+    If used = 0 Then
+        ReDim result(0 To 0)
+        result(0) = 0
+    Else
+        ReDim Preserve result(0 To used - 1)
+    End If
+
+wnaf_finish:
+    If was_negative Then
+        Dim idxDigit As Long
+        For idxDigit = LBound(result) To UBound(result)
+            result(idxDigit) = -result(idxDigit)
+        Next idxDigit
+    End If
+
+    compute_wnaf_digits_for_test = result
+    Exit Function
+
+wnaf_error:
+    ReDim result(0 To 0)
+    result(0) = 0
+    GoTo wnaf_finish
+End Function


### PR DESCRIPTION
## Summary
- replace the placeholder NAF routine with a full windowed NAF encoder that keeps digits in the expected odd range
- map wNAF digits onto the 1760-entry generator table, decoding table entries into EC_POINT instances before accumulation
- add regression coverage that compares the optimized generator path against ec_point_mul and verifies digits outside ±1 appear in the wNAF expansion

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e1313756fc83339572b7e0a1c59645