### PR TITLE
Normalize Montgomery zero handling

### DIFF
--- a/src/BigInt_Montgomery.bas
+++ b/src/BigInt_Montgomery.bas
@@ -349,13 +349,13 @@ Private Sub bn_correct_top(ByRef a As BIGNUM_TYPE)
     ' Garante que top aponte para a palavra mais significativa não-zero
     ' Essencial após operações que podem gerar zeros à esquerda
     
-    ' Remover zeros à esquerda mantendo pelo menos uma palavra
-    Do While a.top > 1 And a.d(a.top - 1) = 0
+    ' Remover zeros à esquerda, permitindo que top chegue a zero quando apropriado
+    Do While a.top > 0 And a.d(a.top - 1) = 0
         a.top = a.top - 1
     Loop
-    
-    ' Garantir que top nunca seja zero (representação canônica)
-    If a.top = 0 Then a.top = 1
+
+    ' Zero canônico deve ter top = 0 e sinal positivo
+    If a.top = 0 Then a.neg = False
 End Sub
 
 ' =============================================================================


### PR DESCRIPTION
## Summary
- ensure bn_correct_top returns top = 0 for true zero values while clearing the sign
- extend Montgomery edge case regression to cover zero results from multiplication and exponentiation

## Testing
- not run (VBA environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e13c4a559c8333b927da4af8d92346