### PR TITLE
Handle degenerate Jacobian adds in Montgomery ladder

### DIFF
--- a/src/EC_Montgomery_Ladder.bas
+++ b/src/EC_Montgomery_Ladder.bas
@@ -280,34 +280,43 @@ Private Function jacobian_add_internal(ByRef result As EC_POINT_JACOBIAN, ByRef 
     Call BN_mod_mul(S2, bCopy.y, Z1Z3, ctx.p)
 
     Call BN_mod_sub(H, U2, U1, ctx.p)
-
-    Call BN_mod_add(tmp1, H, H, ctx.p)
-    Call BN_mod_sqr(I, tmp1, ctx.p)
-    Call BN_mod_mul(J, H, I, ctx.p)
-
     Call BN_mod_sub(r, S2, S1, ctx.p)
-    Call BN_mod_add(r, r, r, ctx.p)
 
-    Call BN_mod_mul(V, U1, I, ctx.p)
+    If BN_is_zero(H) Then
+        If BN_is_zero(r) Then
+            Call jacobian_double_internal(result, aCopy, ctx)
+        Else
+            Call ec_jacobian_set_infinity(result)
+            result.infinity = True
+        End If
+    Else
+        Call BN_mod_add(tmp1, H, H, ctx.p)
+        Call BN_mod_sqr(I, tmp1, ctx.p)
+        Call BN_mod_mul(J, H, I, ctx.p)
 
-    Call BN_mod_sqr(result.x, r, ctx.p)
-    Call BN_mod_sub(result.x, result.x, J, ctx.p)
-    Call BN_mod_add(tmp2, V, V, ctx.p)
-    Call BN_mod_sub(result.x, result.x, tmp2, ctx.p)
+        Call BN_mod_add(r, r, r, ctx.p)
 
-    Call BN_mod_sub(tmp1, V, result.x, ctx.p)
-    Call BN_mod_mul(result.y, r, tmp1, ctx.p)
-    Call BN_mod_mul(tmp2, S1, J, ctx.p)
-    Call BN_mod_add(tmp2, tmp2, tmp2, ctx.p)
-    Call BN_mod_sub(result.y, result.y, tmp2, ctx.p)
+        Call BN_mod_mul(V, U1, I, ctx.p)
 
-    Call BN_mod_add(tmp1, aCopy.z, bCopy.z, ctx.p)
-    Call BN_mod_sqr(tmp1, tmp1, ctx.p)
-    Call BN_mod_sub(tmp1, tmp1, Z1Z1, ctx.p)
-    Call BN_mod_sub(tmp1, tmp1, Z2Z2, ctx.p)
-    Call BN_mod_mul(result.z, tmp1, H, ctx.p)
+        Call BN_mod_sqr(result.x, r, ctx.p)
+        Call BN_mod_sub(result.x, result.x, J, ctx.p)
+        Call BN_mod_add(tmp2, V, V, ctx.p)
+        Call BN_mod_sub(result.x, result.x, tmp2, ctx.p)
 
-    result.infinity = False
+        Call BN_mod_sub(tmp1, V, result.x, ctx.p)
+        Call BN_mod_mul(result.y, r, tmp1, ctx.p)
+        Call BN_mod_mul(tmp2, S1, J, ctx.p)
+        Call BN_mod_add(tmp2, tmp2, tmp2, ctx.p)
+        Call BN_mod_sub(result.y, result.y, tmp2, ctx.p)
+
+        Call BN_mod_add(tmp1, aCopy.z, bCopy.z, ctx.p)
+        Call BN_mod_sqr(tmp1, tmp1, ctx.p)
+        Call BN_mod_sub(tmp1, tmp1, Z1Z1, ctx.p)
+        Call BN_mod_sub(tmp1, tmp1, Z2Z2, ctx.p)
+        Call BN_mod_mul(result.z, tmp1, H, ctx.p)
+
+        result.infinity = False
+    End If
 
     Dim copyA As EC_POINT_JACOBIAN, copyB As EC_POINT_JACOBIAN
     copyA = ec_jacobian_new(): copyB = ec_jacobian_new()

--- a/tests/Constant_Time_Dispatch_Tests.bas
+++ b/tests/Constant_Time_Dispatch_Tests.bas
@@ -183,6 +183,40 @@ Public Sub Run_Constant_Time_Dispatch_Tests()
         End If
     Next idx
 
+    Debug.Print "--- Casos especiais: R + R e R + (-R) ---"
+
+    Dim scalarTwo As BIGNUM_TYPE
+    Dim ladderDouble As EC_POINT
+    Dim expectedDouble As EC_POINT
+    scalarTwo = BN_new()
+    Call BN_set_word(scalarTwo, 2)
+
+    ladderDouble = ec_point_new()
+    expectedDouble = ec_point_new()
+    Call ec_point_double(expectedDouble, ctx.g, ctx)
+
+    If Not ec_point_mul_ladder(ladderDouble, scalarTwo, ctx.g, ctx) Then
+        Debug.Print "[ERRO] Ladder falhou ao duplicar ponto base (R + R)"
+    ElseIf ec_point_cmp(ladderDouble, expectedDouble, ctx) = 0 Then
+        Debug.Print "[OK] Ladder retornou duplicação correta para R + R"
+    Else
+        Debug.Print "[ERRO] Ladder divergente na duplicação R + R"
+    End If
+
+    Dim orderScalar As BIGNUM_TYPE
+    Dim ladderInfinity As EC_POINT
+    orderScalar = BN_new()
+    Call BN_copy(orderScalar, ctx.n)
+    ladderInfinity = ec_point_new()
+
+    If Not ec_point_mul_ladder(ladderInfinity, orderScalar, ctx.g, ctx) Then
+        Debug.Print "[ERRO] Ladder falhou ao multiplicar por ordem (R + (-R))"
+    ElseIf ladderInfinity.infinity Then
+        Debug.Print "[OK] Ladder retornou ponto no infinito para R + (-R)"
+    Else
+        Debug.Print "[ERRO] Ladder não retornou infinito para R + (-R)"
+    End If
+
     If diagnosticsAvailable Then
         Call ladder_set_diagnostics_enabled(False)
     End If


### PR DESCRIPTION
## Summary
- short-circuit Jacobian addition when H=0 to reuse doubling or return infinity instead of running invalid formulas
- extend Montgomery ladder dispatch tests with coverage for R+R and R+(-R) results

## Testing
- not run (not supported in container)

------
https://chatgpt.com/codex/tasks/task_e_68e19f3b626883338adaf7e89e75e4a0