### PR TITLE
Propagate subgroup check failures in point validation

### DIFF
--- a/src/ECDSA_Batch_Verify.bas
+++ b/src/ECDSA_Batch_Verify.bas
@@ -156,7 +156,13 @@ Private Function secp256k1_validate_affine_point_ctx(ByRef point As EC_POINT, By
 
     Dim n_point As EC_POINT
     n_point = ec_point_new()
-    If Not ec_point_mul(n_point, subgroup_order, point, ctx) Then Exit Function
+
+    Dim mul_succeeded As Boolean
+    mul_succeeded = ec_point_mul(n_point, subgroup_order, point, ctx)
+    If Not mul_succeeded Then
+        secp256k1_validate_affine_point_ctx = False
+        Exit Function
+    End If
     If Not n_point.infinity Then Exit Function
 
     secp256k1_validate_affine_point_ctx = True

--- a/src/EC_secp256k1_Arithmetic.bas
+++ b/src/EC_secp256k1_Arithmetic.bas
@@ -38,6 +38,9 @@ Option Base 0
 '
 ' =============================================================================
 
+' Instrumentação de testes: permite simular falhas na multiplicação escalar
+Public ec_point_mul_force_failure As Boolean
+
 ' =============================================================================
 ' ADIÇÃO DE PONTOS DA CURVA ELÍPTICA
 ' =============================================================================
@@ -237,6 +240,11 @@ Public Function ec_point_mul(ByRef result As EC_POINT, ByRef scalar As BIGNUM_TY
     ' -------------------------------------------------------------------------
     ' Inicializar resultado como ponto no infinito
     Call ec_point_set_infinity(result)
+
+    If ec_point_mul_force_failure Then
+        ec_point_mul = False
+        Exit Function
+    End If
 
     If BN_is_zero(scalar) Or point.infinity Then
         ec_point_mul = True

--- a/src/secp256k1_API.bas
+++ b/src/secp256k1_API.bas
@@ -361,7 +361,13 @@ Private Function secp256k1_validate_affine_point(ByRef point As EC_POINT) As Boo
 
     Dim n_point As EC_POINT
     n_point = ec_point_new()
-    If Not ec_point_mul(n_point, subgroup_order, point, ctx) Then Exit Function
+
+    Dim mul_succeeded As Boolean
+    mul_succeeded = ec_point_mul(n_point, subgroup_order, point, ctx)
+    If Not mul_succeeded Then
+        secp256k1_validate_affine_point = False
+        Exit Function
+    End If
     If Not n_point.infinity Then Exit Function
 
     secp256k1_validate_affine_point = True

--- a/tests/Test_Point_Validation_FailFast.bas
+++ b/tests/Test_Point_Validation_FailFast.bas
@@ -1,0 +1,157 @@
+Attribute VB_Name = "Test_Point_Validation_FailFast"
+Option Explicit
+
+'==============================================================================
+' TESTES DE FALHA RÁPIDA PARA VALIDAÇÃO DE PONTOS
+'==============================================================================
+'
+' Propósito: Garante que as rotinas de validação de pontos abortam imediatamente
+'            quando a multiplicação escalar de subgrupo falha.
+' Escopo:    secp256k1_point_decompress (API principal) e ecdsa_batch_verify
+'            (validação com contexto explícito).
+'
+Public Sub test_point_decompress_rejects_on_mul_failure()
+    Debug.Print "=== TESTE: DESCOMPRESSÃO REJEITA QUANDO MULTIPLICAÇÃO FALHA ==="
+
+    On Error GoTo Handler
+
+    If Not secp256k1_init() Then
+        Err.Raise vbObjectError + &H5100&, "test_point_decompress_rejects_on_mul_failure", _
+                  "Falha ao inicializar o contexto secp256k1."
+    End If
+
+    Dim generator As String
+    generator = secp256k1_get_generator()
+
+    Dim baseline As String
+    baseline = secp256k1_point_decompress(generator)
+    If baseline = "" Then
+        Err.Raise vbObjectError + &H5101&, "test_point_decompress_rejects_on_mul_failure", _
+                  "Pré-condição inválida: descompressão do gerador deveria funcionar."
+    End If
+
+    Dim originalUltimate As Boolean
+    Dim originalPlain As Boolean
+    originalUltimate = EC_Multiplication_Dispatch.ec_point_mul_ultimate_force_failure
+    originalPlain = EC_secp256k1_Arithmetic.ec_point_mul_force_failure
+
+    EC_Multiplication_Dispatch.ec_point_mul_ultimate_force_failure = True
+    EC_secp256k1_Arithmetic.ec_point_mul_force_failure = True
+
+    Dim failedCoords As String
+    failedCoords = secp256k1_point_decompress(generator)
+    Debug.Print "Descompressão abortada após falha forçada: ", (failedCoords = "")
+    If failedCoords <> "" Then
+        Err.Raise vbObjectError + &H5102&, "test_point_decompress_rejects_on_mul_failure", _
+                  "secp256k1_point_decompress não rejeitou ponto após falha em ec_point_mul."
+    End If
+
+    Dim errCode As SECP256K1_ERROR
+    errCode = secp256k1_get_last_error()
+    Debug.Print "Erro propagado corretamente: ", (errCode = SECP256K1_ERROR_POINT_NOT_ON_CURVE)
+    If errCode <> SECP256K1_ERROR_POINT_NOT_ON_CURVE Then
+        Err.Raise vbObjectError + &H5103&, "test_point_decompress_rejects_on_mul_failure", _
+                  "Código de erro inesperado após falha de multiplicação na validação."
+    End If
+
+    GoTo Cleanup
+
+Handler:
+    Debug.Print "FALHOU: " & Err.Description
+
+Cleanup:
+    EC_Multiplication_Dispatch.ec_point_mul_ultimate_force_failure = originalUltimate
+    EC_secp256k1_Arithmetic.ec_point_mul_force_failure = originalPlain
+
+    If Err.Number <> 0 Then
+        Dim errNumber As Long, errSource As String, errDescription As String
+        errNumber = Err.Number
+        errSource = Err.Source
+        errDescription = Err.Description
+        Err.Clear
+        Debug.Print "=== TESTE ABORTADO ==="
+        Err.Raise errNumber, errSource, errDescription
+    Else
+        Debug.Print "=== TESTE CONCLUÍDO ==="
+    End If
+End Sub
+
+Public Sub test_batch_validator_rejects_on_mul_failure()
+    Debug.Print "=== TESTE: BATCH VERIFY REJEITA QUANDO MULTIPLICAÇÃO FALHA ==="
+
+    On Error GoTo Handler
+
+    Dim ctx As SECP256K1_CTX
+    ctx = secp256k1_context_create()
+
+    If Not secp256k1_init() Then
+        Err.Raise vbObjectError + &H5200&, "test_batch_validator_rejects_on_mul_failure", _
+                  "Falha ao inicializar o contexto global secp256k1."
+    End If
+
+    Dim private_key As String
+    private_key = "C9AFA9D845BA75166B5C215767B1D6934E50C3DB36E89B127B8A622B120F6721"
+
+    Dim private_bn As BIGNUM_TYPE
+    private_bn = BN_hex2bn(private_key)
+
+    Dim public_key As EC_POINT
+    If Not ec_point_mul_generator(public_key, private_bn, ctx) Then
+        Err.Raise vbObjectError + &H5201&, "test_batch_validator_rejects_on_mul_failure", _
+                  "Falha ao derivar chave pública para o teste de lote."
+    End If
+
+    Dim message As String, hash As String
+    message = "Batch verify rejeição por falha forçada"
+    hash = SHA256_VBA.SHA256_String(message)
+
+    Dim batch(0 To 0) As BATCH_SIGNATURE
+    batch(0).message_hash = hash
+    batch(0).signature = ecdsa_sign_bitcoin_core(hash, private_key, ctx)
+    batch(0).public_key = public_key
+
+    Dim baseline_result As Boolean
+    baseline_result = ecdsa_batch_verify(batch, ctx)
+    Debug.Print "Lote válido aceito antes da falha forçada: ", baseline_result
+    If Not baseline_result Then
+        Err.Raise vbObjectError + &H5202&, "test_batch_validator_rejects_on_mul_failure", _
+                  "Pré-condição inválida: lote válido deveria ser aceito."
+    End If
+
+    Dim originalUltimate As Boolean
+    Dim originalPlain As Boolean
+    originalUltimate = EC_Multiplication_Dispatch.ec_point_mul_ultimate_force_failure
+    originalPlain = EC_secp256k1_Arithmetic.ec_point_mul_force_failure
+
+    EC_Multiplication_Dispatch.ec_point_mul_ultimate_force_failure = True
+    EC_secp256k1_Arithmetic.ec_point_mul_force_failure = True
+
+    Dim failure_result As Boolean
+    failure_result = ecdsa_batch_verify(batch, ctx)
+    Debug.Print "Lote rejeitado após falha forçada: ", (Not failure_result)
+    If failure_result Then
+        Err.Raise vbObjectError + &H5203&, "test_batch_validator_rejects_on_mul_failure", _
+                  "ecdsa_batch_verify aceitou lote mesmo com falha em ec_point_mul durante validação."
+    End If
+
+    GoTo Cleanup
+
+Handler:
+    Debug.Print "FALHOU: " & Err.Description
+
+Cleanup:
+    EC_Multiplication_Dispatch.ec_point_mul_ultimate_force_failure = originalUltimate
+    EC_secp256k1_Arithmetic.ec_point_mul_force_failure = originalPlain
+
+    If Err.Number <> 0 Then
+        Dim errNumber As Long, errSource As String, errDescription As String
+        errNumber = Err.Number
+        errSource = Err.Source
+        errDescription = Err.Description
+        Err.Clear
+        Debug.Print "=== TESTE ABORTADO ==="
+        Err.Raise errNumber, errSource, errDescription
+    Else
+        Debug.Print "=== TESTE CONCLUÍDO ==="
+    End If
+End Sub


### PR DESCRIPTION
## Summary
- capture the return value of `ec_point_mul` inside both affine-point validators so they abort when subgroup multiplication fails
- expose a `ec_point_mul_force_failure` instrumentation knob for tests to simulate plain multiplication failures
- add regression tests that force multiplication failures during decompression and batch verification to prove points are rejected

## Testing
- not run (VBA test harness unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e1a85655d48333afe4caf9a925a006