### PR TITLE
Normalize Bech32 HRP casing and extend tests

### DIFF
--- a/src/Bech32_VBA.bas
+++ b/src/Bech32_VBA.bas
@@ -146,6 +146,15 @@ Public Function Bech32_SegwitEncode(ByVal hrp As String, ByVal witver As Byte, B
     Dim ok As Boolean, i As Long, constv As Long
     Dim s As String
     Const ALPH As String = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+    Dim hrpLower As String, hrpUpper As String
+
+    hrpLower = LCase$(hrp)
+    hrpUpper = UCase$(hrp)
+    If (hrp <> hrpLower) And (hrp <> hrpUpper) Then
+        Bech32_SegwitEncode = ""
+        Exit Function
+    End If
+    hrp = hrpLower
 
     If (Not Not prog) <> 0 Then
         ok = ConvertBits(prog, 8, 5, True, data5)

--- a/tests/Test_Bech32.bas
+++ b/tests/Test_Bech32.bas
@@ -106,6 +106,15 @@ Public Sub Test_Bech32()
     addr_repeat = Bech32_VBA.Bech32_SegwitEncode("bc", 0, repeat_bytes)
     Debug.Print "Determinístico: " & (segwit_addr = addr_repeat)
 
+    ' Teste 6: HRP em diferentes caixas
+    Debug.Print "HRP minúscula permanece minúscula: " & (segwit_addr <> "" And segwit_addr = LCase$(segwit_addr))
+    Dim segwit_addr_upper As String
+    segwit_addr_upper = Bech32_VBA.Bech32_SegwitEncode("BC", 0, hash_bytes)
+    Debug.Print "HRP maiúscula normalizada: " & (segwit_addr_upper <> "" And segwit_addr_upper = LCase$(segwit_addr_upper))
+    Dim segwit_addr_mixed As String
+    segwit_addr_mixed = Bech32_VBA.Bech32_SegwitEncode("Bc", 0, hash_bytes)
+    Debug.Print "HRP mista rejeitada: " & (segwit_addr_mixed = "")
+
     Debug.Print "=== TESTE BECH32 CONCLUÍDO ==="
 End Sub
 ' Funções auxiliares para conversão


### PR DESCRIPTION
## Summary
- reject mixed-case HRPs during SegWit Bech32 encoding and normalize valid HRPs to lowercase
- ensure the generated data portion stays in the same case as the HRP for consistent output
- extend the Bech32 test module with checks for lowercase, uppercase, and mixed-case HRP inputs

## Testing
- not run (Visual Basic test harness not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e1df5ead408333ade1131f48cccc72