### PR TITLE
Validate Bech32 address casing in decoder

### DIFF
--- a/src/Bech32_VBA.bas
+++ b/src/Bech32_VBA.bas
@@ -183,7 +183,15 @@ Public Function Bech32_SegwitDecode(ByVal addr As String, ByRef hrpOut As String
     Dim c As String, val As Long
     Const ALPH As String = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
 
-    addr = LCase$(addr)
+    Dim addrLower As String, addrUpper As String
+    addrLower = LCase$(addr)
+    addrUpper = UCase$(addr)
+    If (addr <> addrLower) And (addr <> addrUpper) Then
+        Bech32_SegwitDecode = False
+        Exit Function
+    End If
+
+    addr = addrLower
     p = InStr(1, addr, "1")
     If p = 0 Or p < 1 Or p + 7 > Len(addr) Then Bech32_SegwitDecode = False: Exit Function
     hrp = left$(addr, p - 1)

--- a/tests/Test_Bech32.bas
+++ b/tests/Test_Bech32.bas
@@ -115,6 +115,21 @@ Public Sub Test_Bech32()
     segwit_addr_mixed = Bech32_VBA.Bech32_SegwitEncode("Bc", 0, hash_bytes)
     Debug.Print "HRP mista rejeitada: " & (segwit_addr_mixed = "")
 
+    ' Teste 7: Decodificação respeitando caixa
+    Dim addr_lower_ok As Boolean, addr_upper_ok As Boolean, addr_mixed_ok As Boolean
+    Dim hrp_case As String, witver_case As Byte, prog_case() As Byte
+
+    addr_lower_ok = Bech32_VBA.Bech32_SegwitDecode(segwit_addr, hrp_case, witver_case, prog_case)
+    addr_upper_ok = Bech32_VBA.Bech32_SegwitDecode(UCase$(segwit_addr), hrp_case, witver_case, prog_case)
+
+    Dim addr_mixed As String
+    addr_mixed = Left$(segwit_addr, 6) & UCase$(Mid$(segwit_addr, 7, 1)) & Mid$(segwit_addr, 8)
+    addr_mixed_ok = Bech32_VBA.Bech32_SegwitDecode(addr_mixed, hrp_case, witver_case, prog_case)
+
+    Debug.Print "Decode minúsculo OK: " & addr_lower_ok
+    Debug.Print "Decode maiúsculo OK: " & addr_upper_ok
+    Debug.Print "Decode caixa mista rejeitado: " & (addr_mixed_ok = False)
+
     Debug.Print "=== TESTE BECH32 CONCLUÍDO ==="
 End Sub
 ' Funções auxiliares para conversão


### PR DESCRIPTION
## Summary
- ensure `Bech32_SegwitDecode` enforces uniform casing before normalising input
- extend Bech32 tests to cover lowercase, uppercase, and mixed-case address decoding behaviour

## Testing
- not run (VBA debug tests require host environment)


------
https://chatgpt.com/codex/tasks/task_e_68e25b324dbc833398820ebc4b49ce74