### PR TITLE
Validate compressed point hex input

### DIFF
--- a/src/EC_secp256k1_Core.bas
+++ b/src/EC_secp256k1_Core.bas
@@ -242,6 +242,12 @@ Public Function ec_point_decompress(ByVal compressed As String, ByRef ctx As SEC
         Exit Function
     End If
 
+    If Not ec_is_hex_string(x_hex) Then
+        Call ec_point_set_infinity(pt)
+        ec_point_decompress = pt
+        Exit Function
+    End If
+
     Dim x As BIGNUM_TYPE, y As BIGNUM_TYPE
     x = BN_hex2bn(x_hex)
     y = BN_new()
@@ -302,6 +308,23 @@ Public Function ec_point_decompress(ByVal compressed As String, ByRef ctx As SEC
 
     Call ec_point_set_affine(pt, x, y)
     ec_point_decompress = pt
+End Function
+
+Private Function ec_is_hex_string(ByVal value As String) As Boolean
+    Dim i As Long, code As Long
+    If Len(value) = 0 Then Exit Function
+
+    For i = 1 To Len(value)
+        code = Asc(Mid$(value, i, 1))
+        Select Case code
+            Case 48 To 57, 65 To 70, 97 To 102
+                ' Válido
+            Case Else
+                Exit Function
+        End Select
+    Next i
+
+    ec_is_hex_string = True
 End Function
 
 Public Function ec_point_to_uncompressed(ByRef point As EC_POINT) As String

--- a/tests/EC_Validation_Tests.bas
+++ b/tests/EC_Validation_Tests.bas
@@ -179,6 +179,17 @@ Private Sub Test_Decompression_Security(ByRef passed As Long, ByRef total As Lon
     End If
     total = total + 1
 
+    Dim invalid_hex_input As String
+    invalid_hex_input = "02ZZBE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798"
+    coords = secp256k1_point_decompress(invalid_hex_input)
+    If coords = "" And secp256k1_get_last_error() = SECP256K1_ERROR_POINT_NOT_ON_CURVE Then
+        passed = passed + 1
+        Debug.Print "APROVADO: Rejeição de entrada com caracteres hex inválidos"
+    Else
+        Debug.Print "FALHOU: Descompressão deveria rejeitar caracteres hex inválidos"
+    End If
+    total = total + 1
+
     Dim invalid_twist As String
     invalid_twist = "030A2D2BA93507F1DF233770C2A797962CC61F6D15DA14ECD47D8D27AE1CD5F853"
     coords = secp256k1_point_decompress(invalid_twist)


### PR DESCRIPTION
## Summary
- ensure ec_point_decompress rejects compressed coordinates with non-hex characters before converting to BIGNUMs
- propagate invalid decompression back through the public API by returning the point at infinity
- extend EC validation tests to cover malformed compressed points with bad hex digits

## Testing
- not run (VBA test harness not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e28cc15af883339875d45b8f0bf166