### PR TITLE
Validate hex parsing for Hash160 and add invalid input tests

### DIFF
--- a/src/Hash160_VBA.bas
+++ b/src/Hash160_VBA.bas
@@ -14,6 +14,11 @@ Option Compare Binary
 ' =====================================================================================
 
 Private Function HexToBytes(ByVal hexStr As String) As Byte()
+    If (Len(hexStr) Mod 2) <> 0 Then
+        Err.Raise vbObjectError + &H160, "Hash160_VBA.HexToBytes", _
+                  "Hex string must contain an even number of characters."
+    End If
+
     Dim n As Long, i As Long
     n = Len(hexStr) \ 2
     Dim b() As Byte
@@ -44,8 +49,14 @@ End Function
 
 Public Function Hash160_Hex(ByVal hexStr As String) As String
     Dim b() As Byte
+    On Error GoTo HexParseError
     b = HexToBytes(hexStr)
+    On Error GoTo 0
     Hash160_Hex = Hash160_Bytes(b)
+    Exit Function
+
+HexParseError:
+    Err.Raise Err.Number, "Hash160_VBA.Hash160_Hex", Err.Description
 End Function
 
 ' ============================== Auto-Testes =========================================

--- a/tests/Test_Hash_Robust.bas
+++ b/tests/Test_Hash_Robust.bas
@@ -304,6 +304,45 @@ Public Sub test_hash_stress()
 End Sub
 
 '==============================================================================
+' TESTES DE VALIDAÇÃO PARA HEX INVÁLIDO
+'==============================================================================
+
+' Propósito: Garante que entradas hexadecimais de comprimento ímpar sejam rejeitadas
+' Algoritmo: Chama Hash160_Hex com strings ímpares e verifica geração de erro
+' Retorno: Relatório de sucesso/erro via Debug.Print
+
+Public Sub test_hash160_invalid_hex()
+    Debug.Print "=== TESTE HASH160 HEX INVÁLIDO ==="
+
+    Dim errOdd1 As Long, errOdd2 As Long
+    Dim result As String
+
+    On Error Resume Next
+    result = Hash160_VBA.Hash160_Hex("0")
+    errOdd1 = Err.Number
+    Debug.Print "Erro para '0': " & errOdd1 & "  Resultado: " & result
+    Err.Clear
+
+    result = Hash160_VBA.Hash160_Hex("ABC")
+    errOdd2 = Err.Number
+    Debug.Print "Erro para 'ABC': " & errOdd2 & "  Resultado: " & result
+    Err.Clear
+    On Error GoTo 0
+
+    Dim allRejected As Boolean
+    allRejected = (errOdd1 <> 0) And (errOdd2 <> 0)
+
+    Debug.Print "Entradas rejeitadas: " & allRejected
+    If allRejected Then
+        Debug.Print "[OK] Hash160 rejeitou hex de comprimento ímpar"
+    Else
+        Debug.Print "[X] Hash160 aceitou hex inválido"
+    End If
+
+    Debug.Print "=== TESTE HEX INVÁLIDO CONCLUÍDO ==="
+End Sub
+
+'==============================================================================
 ' EXECUÇÃO DE TODOS OS TESTES ROBUSTOS
 '==============================================================================
 
@@ -317,6 +356,10 @@ Public Sub test_all_hash_robust()
     Call test_hash_robust()
     Debug.Print ""
     Call test_hash_stress()
+    Debug.Print ""
+    Call test_hash160_invalid_hex()
 
     Debug.Print "=== TODOS OS TESTES ROBUSTOS CONCLUÍDOS ==="
 End Sub
+
+' Fim do módulo de testes robustos de hash


### PR DESCRIPTION
## Summary
- raise an explicit error when Hash160 hex input strings have an odd number of characters and ensure callers propagate the failure
- extend the hash robustness test suite with coverage for odd-length hex strings to confirm they are rejected

## Testing
- not run (environment does not provide a VBA runtime)


------
https://chatgpt.com/codex/tasks/task_e_68e28dd6ca24833399d5f17757ad5089