### PR TITLE
Validate RIPEMD160 hex input length

### DIFF
--- a/src/RIPEMD160_VBA.bas
+++ b/src/RIPEMD160_VBA.bas
@@ -88,6 +88,11 @@ End Function
 
 Public Function RIPEMD160_Hex(ByVal hexStr As String) As String
     Dim n As Long, i As Long, b() As Byte
+
+    If (Len(hexStr) Mod 2) <> 0 Then
+        Err.Raise vbObjectError + 1, "RIPEMD160_Hex", "Hex string must have even length"
+    End If
+
     n = Len(hexStr) \ 2
     If n > 0 Then
         ReDim b(0 To n - 1)
@@ -302,4 +307,17 @@ Public Sub RIPEMD160_SelfTest()
     h = RIPEMD160_String("abc")
     Debug.Print "RIPEMD160(""abc"") = " & h
     Debug.Print "Expect       = 8EB208F7E05D987A9B044A8E98C6B087F15A0BFC"
+
+    Dim errCaught As Boolean
+    On Error Resume Next
+    h = RIPEMD160_Hex("ABC")
+    If Err.Number <> 0 Then
+        errCaught = True
+        Debug.Print "RIPEMD160_Hex(""ABC"") error: " & Err.Number & " - " & Err.Description
+        Err.Clear
+    Else
+        Debug.Print "RIPEMD160_Hex(""ABC"") unexpected success: " & h
+    End If
+    On Error GoTo 0
+    Debug.Print "Odd-length hex raises error: " & errCaught
 End Sub

--- a/tests/Test_RIPEMD160.bas
+++ b/tests/Test_RIPEMD160.bas
@@ -124,6 +124,19 @@ Public Sub test_ripemd160_validation()
     If Len(hash8) = 40 Then passed = passed + 1
     total = total + 1
 
+    ' Teste 9: Hex ímpar deve falhar
+    Dim err_hex As Boolean
+    On Error Resume Next
+    hash1 = RIPEMD160_VBA.RIPEMD160_Hex("ABC")
+    If Err.Number <> 0 Then
+        err_hex = True
+        Err.Clear
+    End If
+    On Error GoTo 0
+    Debug.Print "Erro esperado em hex ímpar: " & err_hex
+    If err_hex Then passed = passed + 1
+    total = total + 1
+
     Debug.Print "=== TESTES RIPEMD-160: " & passed & "/" & total & " APROVADOS ==="
 
     If passed = total Then


### PR DESCRIPTION
## Summary
- raise an error when RIPEMD160_Hex receives an odd-length hex string before allocating buffers
- extend the RIPEMD160 self-test and validation suite to assert the odd-length error path

## Testing
- not run (manual VB modules)


------
https://chatgpt.com/codex/tasks/task_e_68e2908383dc83338e92c0ea58e7ec21