### PR TITLE
Validate Base58 hex parsing and add regression tests

### DIFF
--- a/tests/Test_Base58.bas
+++ b/tests/Test_Base58.bas
@@ -116,6 +116,41 @@ Public Sub Test_Base58()
     Debug.Print "=== TESTE BASE58 CONCLUÍDO ==="
 End Sub
 
+Public Sub Test_Base58_HexParsing()
+    Debug.Print "=== TESTE BASE58 HEX PARSING ==="
+
+    Dim errNum As Long, errDesc As String
+
+    On Error Resume Next
+    Base58_VBA.Base58_SelfTest "123"
+    errNum = Err.Number: errDesc = Err.Description
+    Debug.Print "Odd-length hex rejected: " & (errNum <> 0)
+    Debug.Assert errNum <> 0
+    Debug.Print "Erro: " & errDesc
+    Err.Clear
+    On Error GoTo 0
+
+    On Error Resume Next
+    Base58_VBA.Base58_SelfTest "00GG"
+    errNum = Err.Number: errDesc = Err.Description
+    Debug.Print "Non-hex characters rejected: " & (errNum <> 0)
+    Debug.Assert errNum <> 0
+    Debug.Print "Erro: " & errDesc
+    Err.Clear
+    On Error GoTo 0
+
+    On Error GoTo TestFail
+    Base58_VBA.Base58_SelfTest
+    On Error GoTo 0
+    Debug.Print "Valid Base58 self-test completed sem erros de parsing."
+    Exit Sub
+
+TestFail:
+    Debug.Print "Unexpected Base58 self-test error: " & Err.Description
+    Debug.Assert False
+    On Error GoTo 0
+End Sub
+
 ' Funções auxiliares para conversão
 Private Function HexToBytes(ByVal hexStr As String) As Byte()
     Dim n As Long, i As Long


### PR DESCRIPTION
## Summary
- reject malformed input in `Base58_VBA.HexToBytes` by validating length and characters with descriptive errors
- wrap `DoubleSHA256_4` and `Base58_SelfTest` so hex parsing failures bubble up with contextual error sources
- extend the Base58 test module to cover odd-length and non-hex inputs while confirming valid flows still succeed

## Testing
- not run (manual VBA execution environment not available)


------
https://chatgpt.com/codex/tasks/task_e_68e2b41311188333812236c25bb80d45