### PR TITLE
Handle generator multiply dispatcher failures

### DIFF
--- a/src/secp256k1_API.bas
+++ b/src/secp256k1_API.bas
@@ -538,15 +538,17 @@ Public Function secp256k1_generator_multiply(ByVal scalar_hex As String) As Stri
     result = ec_point_new()
 
     If Not ec_point_mul_generator(result, scalar, ctx) Then
+        last_error = SECP256K1_ERROR_COMPUTATION_FAILED
         secp256k1_generator_multiply = ""
         Exit Function
     End If
-    
+
     If result.infinity Then
-        secp256k1_generator_multiply = "00"
+        last_error = SECP256K1_ERROR_COMPUTATION_FAILED
+        secp256k1_generator_multiply = ""
         Exit Function
     End If
-    
+
     secp256k1_generator_multiply = ec_point_compress(result, ctx)
 End Function
 

--- a/tests/Test_API_Complete.bas
+++ b/tests/Test_API_Complete.bas
@@ -530,6 +530,21 @@ Private Sub Test_API_Error_Handling(ByRef passed As Long, ByRef total As Long)
     End If
     total = total + 1
 
+    Dim generator_failure As String
+    generator_failure = secp256k1_generator_multiply(forced_private)
+
+    forced_error = secp256k1_get_last_error()
+
+    If generator_failure = "" And forced_error = SECP256K1_ERROR_COMPUTATION_FAILED Then
+        passed = passed + 1
+        Debug.Print "APROVADO: Falha na multiplicação do gerador retorna erro explícito"
+    Else
+        Debug.Print "FALHOU: Multiplicação do gerador não propagou falha esperada"
+        Debug.Print "  Retorno: " & generator_failure
+        Debug.Print "  last_error: " & forced_error
+    End If
+    total = total + 1
+
     EC_Multiplication_Dispatch.ec_point_mul_ultimate_force_failure = original_force_failure
 End Sub
 


### PR DESCRIPTION
## Summary
- ensure secp256k1_generator_multiply propagates dispatcher failures by setting the computation error
- treat unexpected infinity results as errors instead of returning "00"
- extend API error-handling tests to cover forced generator multiplication failure

## Testing
- not run (VBA test harness not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2c76064688333af9061d1c1e9bc96