### PR TITLE
Propagate point multiply failure states

### DIFF
--- a/src/secp256k1_API.bas
+++ b/src/secp256k1_API.bas
@@ -465,6 +465,7 @@ Public Function secp256k1_point_multiply(ByVal scalar_hex As String, ByVal point
 
     scalar = BN_hex2bn(scalar_hex)
     zero = BN_new()
+    Call BN_zero(zero)
 
     If ctx.n.top = 0 Then
         curve_order = BN_hex2bn("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141")
@@ -494,7 +495,8 @@ Public Function secp256k1_point_multiply(ByVal scalar_hex As String, ByVal point
     End If
 
     If result.infinity Then
-        secp256k1_point_multiply = "00"
+        last_error = SECP256K1_ERROR_COMPUTATION_FAILED
+        secp256k1_point_multiply = ""
         Exit Function
     End If
 
@@ -505,6 +507,9 @@ Public Function secp256k1_point_multiply(ByVal scalar_hex As String, ByVal point
     End If
 
     secp256k1_point_multiply = ec_point_compress(result, ctx)
+    If secp256k1_point_multiply = "" Then
+        last_error = SECP256K1_ERROR_COMPUTATION_FAILED
+    End If
 End Function
 
 Public Function secp256k1_generator_multiply(ByVal scalar_hex As String) As String
@@ -522,6 +527,7 @@ Public Function secp256k1_generator_multiply(ByVal scalar_hex As String) As Stri
 
     scalar = BN_hex2bn(scalar_hex)
     zero = BN_new()
+    Call BN_zero(zero)
 
     If ctx.n.top = 0 Then
         curve_order = BN_hex2bn("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141")
@@ -538,16 +544,21 @@ Public Function secp256k1_generator_multiply(ByVal scalar_hex As String) As Stri
     result = ec_point_new()
 
     If Not ec_point_mul_generator(result, scalar, ctx) Then
+        last_error = SECP256K1_ERROR_COMPUTATION_FAILED
         secp256k1_generator_multiply = ""
         Exit Function
     End If
-    
+
     If result.infinity Then
-        secp256k1_generator_multiply = "00"
+        last_error = SECP256K1_ERROR_COMPUTATION_FAILED
+        secp256k1_generator_multiply = ""
         Exit Function
     End If
-    
+
     secp256k1_generator_multiply = ec_point_compress(result, ctx)
+    If secp256k1_generator_multiply = "" Then
+        last_error = SECP256K1_ERROR_COMPUTATION_FAILED
+    End If
 End Function
 
 ' =============================================================================

--- a/tests/Test_API_Complete.bas
+++ b/tests/Test_API_Complete.bas
@@ -530,6 +530,39 @@ Private Sub Test_API_Error_Handling(ByRef passed As Long, ByRef total As Long)
     End If
     total = total + 1
 
+    Dim generator_failure As String
+    generator_failure = secp256k1_generator_multiply(forced_private)
+
+    forced_error = secp256k1_get_last_error()
+
+    If generator_failure = "" And forced_error = SECP256K1_ERROR_COMPUTATION_FAILED Then
+        passed = passed + 1
+        Debug.Print "APROVADO: Falha na multiplicação do gerador retorna erro explícito"
+    Else
+        Debug.Print "FALHOU: Multiplicação do gerador não propagou falha esperada"
+        Debug.Print "  Retorno: " & generator_failure
+        Debug.Print "  last_error: " & forced_error
+    End If
+    total = total + 1
+
+    Dim generator As String
+    generator = secp256k1_get_generator()
+
+    Dim point_mul_failure As String
+    point_mul_failure = secp256k1_point_multiply(forced_private, generator)
+
+    forced_error = secp256k1_get_last_error()
+
+    If point_mul_failure = "" And forced_error = SECP256K1_ERROR_COMPUTATION_FAILED Then
+        passed = passed + 1
+        Debug.Print "APROVADO: Falha na multiplicação de ponto retorna erro explícito"
+    Else
+        Debug.Print "FALHOU: Multiplicação de ponto não propagou falha esperada"
+        Debug.Print "  Retorno: " & point_mul_failure
+        Debug.Print "  last_error: " & forced_error
+    End If
+    total = total + 1
+
     EC_Multiplication_Dispatch.ec_point_mul_ultimate_force_failure = original_force_failure
 End Sub
 


### PR DESCRIPTION
## Summary
- flag unexpected infinity or compression failures in `secp256k1_point_multiply`
- extend API error-handling tests to cover forced failures in generic point multiplication

## Testing
- not run (VBA test harness not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e2c76064688333af9061d1c1e9bc96