### PR TITLE
Ensure security mode defaults to enabled

### DIFF
--- a/src/Advanced_Features.bas
+++ b/src/Advanced_Features.bas
@@ -6,21 +6,39 @@ Option Explicit
 ' =============================================================================
 
 Private security_mode As Boolean
+Private security_mode_initialized As Boolean
+
+Public Sub initialize_security_mode()
+    ' Garantir que o modo de segurança inicie como True na primeira carga
+    If Not security_mode_initialized Then
+        security_mode = True
+        security_mode_initialized = True
+    End If
+End Sub
+
+Private Sub ensure_security_mode_initialized()
+    If Not security_mode_initialized Then
+        Call initialize_security_mode
+    End If
+End Sub
 
 Public Sub enable_security_mode()
     ' Ativa modo de segurança máxima (constant-time operations)
+    Call ensure_security_mode_initialized()
     security_mode = True
     Debug.Print "[SECURITY] Modo constant-time ativado"
 End Sub
 
 Public Sub disable_security_mode()
     ' Desativa modo de segurança (máxima performance)
+    Call ensure_security_mode_initialized()
     security_mode = False
     Debug.Print "[PERFORMANCE] Modo máxima performance ativado"
 End Sub
 
 Public Function require_constant_time() As Boolean
     ' Verifica se operações constant-time são necessárias
+    Call ensure_security_mode_initialized()
     require_constant_time = security_mode
 End Function
 

--- a/src/secp256k1_API.bas
+++ b/src/secp256k1_API.bas
@@ -78,7 +78,8 @@ Public Function secp256k1_init() As Boolean
     
     last_error = SECP256K1_OK
     ctx = secp256k1_context_create()
-    
+    Call initialize_security_mode
+
     ' Carregar tabelas pré-computadas para aceleração das operações
     If init_precomputed_tables() Then
         secp256k1_init = True

--- a/tests/Constant_Time_Dispatch_Tests.bas
+++ b/tests/Constant_Time_Dispatch_Tests.bas
@@ -29,7 +29,13 @@ Public Sub Run_Constant_Time_Dispatch_Tests()
     Dim api_point_hex As String
     Dim api_result As String
 
-    Call enable_security_mode
+    Debug.Print "Confirmando modo seguro padrão após inicialização..."
+    If require_constant_time() Then
+        Debug.Print "[OK] Modo constant-time ativo por padrão"
+    Else
+        Debug.Print "[WARN] Modo constant-time não estava ativo - habilitando para os testes"
+        Call enable_security_mode
+    End If
 
     Dim diagnosticsAvailable As Boolean
     diagnosticsAvailable = ladder_diagnostics_available()

--- a/tests/Performance_Audit.bas
+++ b/tests/Performance_Audit.bas
@@ -9,18 +9,33 @@ Option Base 0
 
 Public Sub Run_Performance_Audit()
     Debug.Print "=== AUDITORIA DE PERFORMANCE SECP256K1_EXCEL ==="
-    
+
     Call secp256k1_init
-    
+
+    Dim secureDefault As Boolean
+    secureDefault = require_constant_time()
+
+    If secureDefault Then
+        Debug.Print "[INFO] Modo constant-time ativo por padrão; desativando temporariamente para benchmarks"
+        Call disable_security_mode
+    Else
+        Debug.Print "[INFO] Benchmarks já estão com modo constant-time desativado"
+    End If
+
     ' 1. Benchmark operações básicas
     Call Benchmark_Basic_Operations
-    
+
     ' 2. Benchmark otimizações
     Call Benchmark_Optimizations
-    
+
     ' 3. Benchmark casos reais
     Call Benchmark_Real_World
-    
+
+    If secureDefault Then
+        Debug.Print "[INFO] Reativando modo constant-time após benchmarks"
+        Call enable_security_mode
+    End If
+
     Debug.Print "=== AUDITORIA DE PERFORMANCE CONCLUÍDA ==="
 End Sub
 


### PR DESCRIPTION
## Summary
- initialize the security mode flag the first time Advanced_Features loads so constant-time paths start enabled
- call the initializer during `secp256k1_init` to ensure the API enables the secure default automatically
- update tests and performance audit messaging to reflect the default secure mode while documenting how to disable it for benchmarks

## Testing
- not run (VBA tests not automated in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e2dba248d88333b0d40c4a5ae4938a