### PR TITLE
Document security safeguards for demos, constant-time mode, and entropy

### DIFF
--- a/docs/SECURITY_NOTES.md
+++ b/docs/SECURITY_NOTES.md
@@ -1,0 +1,21 @@
+# Segurança da API secp256k1_VBA
+
+Este documento resume medidas implementadas para evitar exposição acidental de materiais sensíveis e garantir a coleta confiável de entropia durante o uso da biblioteca.
+
+## Demonstrações da API
+
+As rotinas de demonstração (`secp256k1_demo`, `secp256k1_demo_bitcoin_address` e `secp256k1_demo_key_import`) agora aceitam o parâmetro opcional `reveal_secrets`. As chaves privadas, chaves públicas e assinaturas geradas só são impressas quando o chamador define explicitamente `reveal_secrets := True`, permitindo que ambientes de produção executem as demos sem vazar segredos.
+
+## Modo constant-time
+
+O modo constant-time passou a ser inicializado automaticamente durante `secp256k1_init`, através da rotina `initialize_security_mode`. Operações de multiplicação escalar e exponenciação modular adotam o caminho sem ramificações condicionadas a segredos por padrão, reduzindo vetores de ataque por canal lateral. Bancos de testes e benchmarks ainda podem desativar o modo chamando `disable_security_mode` quando necessário.
+
+## Coleta de entropia
+
+A função `fill_random_bytes` agora se apoia em `GetSecureRandomBytes`, que seleciona o melhor provedor disponível em tempo de execução:
+
+- `BCryptGenRandom` (Windows)
+- `SystemFunction036` (Windows legacy)
+- `SecRandomCopyBytes` (macOS)
+
+Se todos os provedores falharem, a rotina gera um erro (`vbObjectError + &H1000&`) para forçar tratamento explícito em vez de prosseguir com entropia insuficiente.


### PR DESCRIPTION
## Summary
- add SECURITY_NOTES.md capturing the reveal_secrets guard in demos, the constant-time default, and secure entropy fallbacks

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e2d8e7911c8333818c6315f6d5a3b5