### PR TITLE
Restore constant-time defaults after context resets

### DIFF
--- a/docs/SECURITY_NOTES.md
+++ b/docs/SECURITY_NOTES.md
@@ -1,0 +1,21 @@
+# Segurança da API secp256k1_VBA
+
+Este documento resume medidas implementadas para evitar exposição acidental de materiais sensíveis e garantir a coleta confiável de entropia durante o uso da biblioteca.
+
+## Demonstrações da API
+
+As rotinas de demonstração (`secp256k1_demo`, `secp256k1_demo_bitcoin_address` e `secp256k1_demo_key_import`) agora aceitam o parâmetro opcional `reveal_secrets`. As chaves privadas, chaves públicas e assinaturas geradas só são impressas quando o chamador define explicitamente `reveal_secrets := True`, permitindo que ambientes de produção executem as demos sem vazar segredos.
+
+## Modo constant-time
+
+O modo constant-time passou a ser inicializado automaticamente durante `secp256k1_init`, através da rotina `initialize_security_mode`. Operações de multiplicação escalar e exponenciação modular adotam o caminho sem ramificações condicionadas a segredos por padrão, reduzindo vetores de ataque por canal lateral. Bancos de testes e benchmarks ainda podem desativar o modo chamando `disable_security_mode` quando necessário. Chamadas subsequentes a `secp256k1_reset_context_for_tests` restauram o modo seguro, evitando que execuções posteriores permaneçam com otimizações inseguras ativadas por engano.
+
+## Coleta de entropia
+
+A função `fill_random_bytes` agora se apoia em `GetSecureRandomBytes`, que seleciona o melhor provedor disponível em tempo de execução:
+
+- `BCryptGenRandom` (Windows)
+- `SystemFunction036` (Windows legacy)
+- `SecRandomCopyBytes` (macOS)
+
+Se todos os provedores falharem, a rotina gera um erro (`vbObjectError + &H1000&`) para forçar tratamento explícito em vez de prosseguir com entropia insuficiente.

--- a/src/Advanced_Features.bas
+++ b/src/Advanced_Features.bas
@@ -9,11 +9,12 @@ Private security_mode As Boolean
 Private security_mode_initialized As Boolean
 
 Public Sub initialize_security_mode()
-    ' Garantir que o modo de segurança inicie como True na primeira carga
+    ' Garantir que o modo de segurança seja ativado sempre que a inicialização ocorrer
     If Not security_mode_initialized Then
-        security_mode = True
         security_mode_initialized = True
     End If
+
+    security_mode = True
 End Sub
 
 Private Sub ensure_security_mode_initialized()

--- a/src/secp256k1_API.bas
+++ b/src/secp256k1_API.bas
@@ -654,6 +654,7 @@ Public Sub secp256k1_reset_context_for_tests()
     ctx = empty_ctx
     last_error = SECP256K1_OK
     is_initialized = False
+    Call initialize_security_mode
 End Sub
 
 ' =============================================================================

--- a/tests/Security_Mode_Tests.bas
+++ b/tests/Security_Mode_Tests.bas
@@ -1,0 +1,38 @@
+Attribute VB_Name = "Security_Mode_Tests"
+Option Explicit
+Option Compare Binary
+Option Base 0
+
+'==============================================================================
+' TESTES DE SEGURANÇA: MODO CONSTANT-TIME
+'==============================================================================
+
+Public Sub Test_Security_Mode_Defaults()
+    ' Garante que o modo constant-time permanece habilitado por padrão mesmo após resets de contexto
+    Call secp256k1_init
+    If Not require_constant_time() Then
+        Err.Raise vbObjectError + &H2001&, "Test_Security_Mode_Defaults", _
+                  "O modo constant-time deveria estar habilitado imediatamente após secp256k1_init."
+    End If
+
+    ' Desativar explicitamente para simular cenários de benchmark
+    Call disable_security_mode
+    If require_constant_time() Then
+        Err.Raise vbObjectError + &H2002&, "Test_Security_Mode_Defaults", _
+                  "O modo constant-time deveria estar desabilitado após chamar disable_security_mode."
+    End If
+
+    ' Resetar o contexto para emular uma nova sessão
+    Call secp256k1_reset_context_for_tests
+    If Not require_constant_time() Then
+        Err.Raise vbObjectError + &H2003&, "Test_Security_Mode_Defaults", _
+                  "O modo constant-time deveria ser restaurado para True após resetar o contexto."
+    End If
+
+    ' Reexecutar a inicialização completa e validar novamente
+    Call secp256k1_init
+    If Not require_constant_time() Then
+        Err.Raise vbObjectError + &H2004&, "Test_Security_Mode_Defaults", _
+                  "O modo constant-time deveria permanecer habilitado após nova inicialização."
+    End If
+End Sub


### PR DESCRIPTION
## Summary
- make initialize_security_mode always reactivate the constant-time guard even after prior disables
- ensure secp256k1_reset_context_for_tests restores the secure default and cover the flow with a regression test
- document that resetting the test context re-enables the constant-time safeguards

## Testing
- not run (VBA macros require Excel host)


------
https://chatgpt.com/codex/tasks/task_e_68e2d8e7911c8333818c6315f6d5a3b5