### PR TITLE
Add tests for custom RNG providers in ECDSA batch verification

### DIFF
--- a/src/ECDSA_Batch_Verify.bas
+++ b/src/ECDSA_Batch_Verify.bas
@@ -206,3 +206,8 @@ Private Function generate_random_coefficient(ByRef ctx As SECP256K1_CTX) As BIGN
     Err.Raise vbObjectError + &H1201&, "generate_random_coefficient", _
               "Não foi possível gerar coeficiente aleatório válido após múltiplas tentativas."
 End Function
+
+Public Function ecdsa_batch_debug_generate_coefficient(ByRef ctx As SECP256K1_CTX) As BIGNUM_TYPE
+    ' Função auxiliar para testes: expõe generate_random_coefficient com o dispatcher atual
+    ecdsa_batch_debug_generate_coefficient = generate_random_coefficient(ctx)
+End Function

--- a/tests/MockBatchRNG.cls
+++ b/tests/MockBatchRNG.cls
@@ -1,0 +1,87 @@
+VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = "MockBatchRNG"
+Option Explicit
+
+Private storedBytes() As Byte
+Private hasPattern As Boolean
+
+Public ShouldRaiseError As Boolean
+Public RaiseErrorAfter As Long
+Public CallCount As Long
+Public ErrorCount As Long
+
+Public Sub ResetState()
+    Call ClearPattern
+    ShouldRaiseError = False
+    RaiseErrorAfter = 0
+    CallCount = 0
+    ErrorCount = 0
+End Sub
+
+Public Sub ClearPattern()
+    Erase storedBytes
+    hasPattern = False
+End Sub
+
+Public Sub SetFixedHex(ByVal hexString As String)
+    Dim cleaned As String
+    cleaned = Replace(hexString, " ", "")
+    cleaned = Replace(cleaned, vbCr, "")
+    cleaned = Replace(cleaned, vbLf, "")
+
+    If Len(cleaned) = 0 Or (Len(cleaned) Mod 2) <> 0 Then
+        Err.Raise vbObjectError + &H4301&, "MockBatchRNG.SetFixedHex", _
+                  "A string hexadecimal deve conter um número par de dígitos."
+    End If
+
+    Dim byteCount As Long
+    byteCount = Len(cleaned) \ 2
+    ReDim storedBytes(0 To byteCount - 1)
+
+    Dim i As Long
+    For i = 0 To byteCount - 1
+        storedBytes(i) = CByte(CLng("&H" & Mid$(cleaned, (i * 2) + 1, 2)))
+    Next i
+
+    hasPattern = True
+End Sub
+
+Public Function FillRandomBytes(buffer() As Byte) As Boolean
+    CallCount = CallCount + 1
+
+    If ShouldRaiseError Then
+        If RaiseErrorAfter <= 0 Then
+            ErrorCount = ErrorCount + 1
+            Err.Raise vbObjectError + &H4300&, "MockBatchRNG.FillRandomBytes", _
+                      "Erro simulado no provedor de aleatoriedade."
+        ElseIf CallCount >= RaiseErrorAfter Then
+            ErrorCount = ErrorCount + 1
+            Err.Raise vbObjectError + &H4300&, "MockBatchRNG.FillRandomBytes", _
+                      "Erro simulado no provedor de aleatoriedade."
+        End If
+    End If
+
+    If Not hasPattern Then
+        ReDim storedBytes(LBound(buffer) To UBound(buffer))
+
+        Dim idx As Long
+        For idx = LBound(storedBytes) To UBound(storedBytes)
+            storedBytes(idx) = CByte(((idx - LBound(storedBytes)) * 37) And &HFF&)
+        Next idx
+
+        hasPattern = True
+    End If
+
+    Dim patternLen As Long
+    patternLen = UBound(storedBytes) - LBound(storedBytes) + 1
+
+    Dim outIndex As Long
+    For outIndex = LBound(buffer) To UBound(buffer)
+        buffer(outIndex) = storedBytes(((outIndex - LBound(buffer)) Mod patternLen) + LBound(storedBytes))
+    Next outIndex
+
+    FillRandomBytes = True
+End Function

--- a/tests/Test_ECDSA_Batch_RNG.bas
+++ b/tests/Test_ECDSA_Batch_RNG.bas
@@ -1,0 +1,122 @@
+Attribute VB_Name = "Test_ECDSA_Batch_RNG"
+Option Explicit
+
+Public Sub test_ecdsa_batch_rng_custom_provider()
+    Debug.Print "=== TESTE: RNG personalizado para coeficientes do batch ==="
+
+    Dim ctx As SECP256K1_CTX
+    Dim provider As MockBatchRNG
+    Dim coeff As BIGNUM_TYPE
+    Dim coeffHex As String
+
+    On Error GoTo Fail
+
+    Call secp256k1_init
+    ctx = secp256k1_context_create()
+
+    Set provider = New MockBatchRNG
+    Call provider.SetFixedHex("A1B2C3D4E5F60718293A4B5C6D7E8F90")
+    provider.RaiseErrorAfter = 0
+    provider.ShouldRaiseError = False
+
+    Call ecdsa_batch_set_rng_provider(provider)
+
+    coeff = ecdsa_batch_debug_generate_coefficient(ctx)
+    coeffHex = BN_bn2hex(coeff)
+
+    Debug.Print "Coeficiente determinístico: ", coeffHex
+    Debug.Print "Chamadas ao provedor: ", provider.CallCount
+
+    If provider.CallCount <> 1 Then
+        Err.Raise vbObjectError + &H4310&, "test_ecdsa_batch_rng_custom_provider", _
+                  "O provedor deveria ter sido chamado exatamente uma vez."
+    End If
+
+    If coeffHex <> "A1B2C3D4E5F60718293A4B5C6D7E8F90" Then
+        Err.Raise vbObjectError + &H4311&, "test_ecdsa_batch_rng_custom_provider", _
+                  "O coeficiente retornado não corresponde ao padrão injetado."
+    End If
+
+    If BN_is_zero(coeff) Then
+        Err.Raise vbObjectError + &H4312&, "test_ecdsa_batch_rng_custom_provider", _
+                  "O coeficiente gerado não pode ser zero."
+    End If
+
+    Debug.Print "[OK] Provedor customizado alimentou coeficiente determinístico"
+
+    Call ecdsa_batch_set_rng_provider(Nothing)
+    Set provider = Nothing
+    Exit Sub
+
+Fail:
+    Dim errNumber As Long, errSource As String, errDescription As String
+    errNumber = Err.Number
+    errSource = Err.Source
+    errDescription = Err.Description
+
+    On Error Resume Next
+    Call ecdsa_batch_set_rng_provider(Nothing)
+    Set provider = Nothing
+    On Error GoTo 0
+
+    Err.Raise errNumber, errSource, errDescription
+End Sub
+
+Public Sub test_ecdsa_batch_rng_provider_fallback()
+    Debug.Print "=== TESTE: Fallback para entropia padrão no batch ==="
+
+    Dim ctx As SECP256K1_CTX
+    Dim provider As MockBatchRNG
+    Dim coeff As BIGNUM_TYPE
+
+    On Error GoTo Fail
+
+    Call secp256k1_init
+    ctx = secp256k1_context_create()
+
+    Set provider = New MockBatchRNG
+    provider.ShouldRaiseError = True
+    provider.RaiseErrorAfter = 1
+
+    Call ecdsa_batch_set_rng_provider(provider)
+
+    coeff = ecdsa_batch_debug_generate_coefficient(ctx)
+
+    Debug.Print "Chamadas ao provedor antes do fallback: ", provider.CallCount
+    Debug.Print "Erros simulados pelo provedor: ", provider.ErrorCount
+    Debug.Print "Coeficiente pós-fallback (hex): ", BN_bn2hex(coeff)
+
+    If provider.CallCount <> 1 Then
+        Err.Raise vbObjectError + &H4313&, "test_ecdsa_batch_rng_provider_fallback", _
+                  "O provedor deveria ter sido invocado exatamente uma vez antes do fallback."
+    End If
+
+    If provider.ErrorCount <> 1 Then
+        Err.Raise vbObjectError + &H4314&, "test_ecdsa_batch_rng_provider_fallback", _
+                  "Era esperado exatamente um erro simulado antes do fallback."
+    End If
+
+    If BN_is_zero(coeff) Then
+        Err.Raise vbObjectError + &H4315&, "test_ecdsa_batch_rng_provider_fallback", _
+                  "O coeficiente obtido após o fallback não pode ser zero."
+    End If
+
+    Debug.Print "[OK] Falha do provedor personalizado acionou fallback seguro"
+
+    Call ecdsa_batch_set_rng_provider(Nothing)
+    Set provider = Nothing
+    Exit Sub
+
+Fail:
+    Dim errNumber As Long, errSource As String, errDescription As String
+    errNumber = Err.Number
+    errSource = Err.Source
+    errDescription = Err.Description
+
+    On Error Resume Next
+    Call ecdsa_batch_set_rng_provider(Nothing)
+    Set provider = Nothing
+    On Error GoTo 0
+
+    Err.Raise errNumber, errSource, errDescription
+End Sub

--- a/tests/Test_RNG_Override.bas
+++ b/tests/Test_RNG_Override.bas
@@ -5,6 +5,8 @@ Public Sub Run_RNG_Override_Tests()
     Debug.Print "=== TESTES RNG OVERRIDE ==="
     Call Test_RNG_Override_Deterministico
     Call Test_RNG_Override_BufferVazio
+    Call test_ecdsa_batch_rng_custom_provider
+    Call test_ecdsa_batch_rng_provider_fallback
     Debug.Print "=== TESTES RNG OVERRIDE CONCLUÍDOS ==="
 End Sub
 


### PR DESCRIPTION
## Summary
- expose a debug helper that lets tests invoke the batch coefficient RNG pipeline directly
- add a mock RNG provider class and targeted tests covering deterministic output and fallback handling
- hook the new checks into the existing RNG override test suite so they run with the rest of the randomness diagnostics

## Testing
- not run (VBA environment)


------
https://chatgpt.com/codex/tasks/task_e_68e2ec2a38ac83338348bad84c04ccd2